### PR TITLE
Add incomplete_address? check method

### DIFF
--- a/lib/super_good/solidus_taxjar/tax_calculator.rb
+++ b/lib/super_good/solidus_taxjar/tax_calculator.rb
@@ -12,7 +12,7 @@ module SuperGood
 
       def calculate
         return no_tax if SuperGood::SolidusTaxJar.test_mode
-        return no_tax if order.tax_address.empty? || order.line_items.none?
+        return no_tax if incomplete_address?(order.tax_address) || order.line_items.none?
         return no_tax unless taxable_address? order.tax_address
 
         cache do
@@ -149,6 +149,16 @@ module SuperGood
 
       def line_item_tax_label(taxjar_line_item, spree_line_item)
         SuperGood::SolidusTaxJar.line_item_tax_label_maker.(taxjar_line_item, spree_line_item)
+      end
+
+      def incomplete_address?(tax_address)
+        [
+          tax_address.address1,
+          tax_address.city,
+          tax_address&.state&.abbr || tax_address.state_name,
+          tax_address.zipcode,
+          tax_address.country.iso
+        ].any?(&:blank?)
       end
     end
   end

--- a/lib/super_good/solidus_taxjar/version.rb
+++ b/lib/super_good/solidus_taxjar/version.rb
@@ -1,5 +1,5 @@
 module SuperGood
   module SolidusTaxJar
-    VERSION = "0.6.0"
+    VERSION = "0.6.1"
   end
 end

--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
       let(:address) do
         ::Spree::Address.new(
           first_name: "Ronnie James",
+          zipcode: "90210",
+          address1: "9900 Wilshire Blvd",
+          city: "Beverly Hills",
+          state_name: "California",
           country: ::Spree::Country.new(iso: "US")
         )
       end
@@ -95,6 +99,10 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
       let(:address) do
         ::Spree::Address.new(
           first_name: "Ronnie James",
+          zipcode: "90210",
+          address1: "9900 Wilshire Blvd",
+          city: "Beverly Hills",
+          state_name: "California",
           country: ::Spree::Country.new(iso: "US")
         )
       end
@@ -123,6 +131,10 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
       let(:address) do
         ::Spree::Address.new(
           first_name: "Ronnie James",
+          zipcode: "90210",
+          address1: "9900 Wilshire Blvd",
+          city: "Beverly Hills",
+          state_name: "California",
           country: ::Spree::Country.new(iso: "US")
         )
       end


### PR DESCRIPTION
Solidus has deprecated the `empty?` method on https://github.com/solidusio/solidus/pull/1686 . 
This adds a private `incomplete_address?` method for avoid future problems and remove the deprecation warning in projects that uses this gem.