### PR TITLE
Add guard clause for TaxLocation addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.6.2
+- Updated `incomplete_address?` method to verify if a `tax_address` is a `Spree::Tax::TaxLocation`. `Spree::Tax::TaxLocation` is considered an incomplete address.
+
 ## v0.6.1
 
 - Stopped using the deprecated method `Spree::Address#empty?` in favour of simply checking that we have all of the fields on the address required for doing a TaxJar lookup.

--- a/lib/super_good/solidus_taxjar/tax_calculator.rb
+++ b/lib/super_good/solidus_taxjar/tax_calculator.rb
@@ -152,6 +152,8 @@ module SuperGood
       end
 
       def incomplete_address?(tax_address)
+        return true if tax_address.is_a?(Spree::Tax::TaxLocation)
+
         [
           tax_address.address1,
           tax_address.city,

--- a/lib/super_good/solidus_taxjar/version.rb
+++ b/lib/super_good/solidus_taxjar/version.rb
@@ -1,5 +1,5 @@
 module SuperGood
   module SolidusTaxJar
-    VERSION = "0.6.1"
+    VERSION = "0.6.2"
   end
 end

--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -74,6 +74,25 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
       end
     end
 
+    context "when the order has an incomplete tax address" do
+      let(:address) do
+        ::Spree::Address.new(
+          first_name: "Ronnie James",
+          zipcode: nil,
+          address1: nil,
+          city: "Beverly Hills",
+          state_name: "California",
+          country: ::Spree::Country.new(iso: "US")
+        )
+      end
+
+      it "returns no taxes" do
+        expect(subject.order_id).to eq order.id
+        expect(subject.shipment_taxes).to be_empty
+        expect(subject.line_item_taxes).to be_empty
+      end
+    end
+
     context "when the order has no line items" do
       let(:address) do
         ::Spree::Address.new(


### PR DESCRIPTION
From Solidus [Documentation](https://guides.solidus.io/developers/taxation/overview.html#use-code-spree-taxlocation-code-as-the-tax-address): 
> An order's tax_address can – through duck typing  – be a Spree::TaxLocation instead of the shipping address.

This adds a guard clause that validates if the tax_address is a TaxLocation, in this case we know that the address is incomplete.