### PR TITLE
Add test that covers behaviour with TaxLocation

### DIFF
--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
       end
     end
 
+    context "when the order has no tax address" do
+      let(:address) { nil }
+
+      it "returns no taxes" do
+        expect(subject.order_id).to eq order.id
+        expect(subject.shipment_taxes).to be_empty
+        expect(subject.line_item_taxes).to be_empty
+      end
+    end
+
     context "when the order has no line items" do
       let(:address) do
         ::Spree::Address.new(


### PR DESCRIPTION
When an order doesn't have a tax_address, it will rely on the order's
store to build a "TaxAddress" for use as the "tax address which in an
ideal world would be much more address-like... but unfortunately it's
not.