### PR TITLE
Make shipping amount calculator configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Make shipping amounts configurable to make it easier to support order-level adjustments.
+
 ## v0.9.1
 
 - Fixed unreliable default cache key implementation.

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -16,6 +16,7 @@ module SuperGood
       attr_accessor :discount_calculator
       attr_accessor :exception_handler
       attr_accessor :line_item_tax_label_maker
+      attr_accessor :shipping_calculator
       attr_accessor :shipping_tax_label_maker
       attr_accessor :taxable_address_check
       attr_accessor :test_mode
@@ -28,6 +29,7 @@ module SuperGood
       Rails.logger.error "An error occurred while fetching TaxJar tax rates - #{e}: #{e.message}"
     }
     self.line_item_tax_label_maker = ->(taxjar_line_item, spree_line_item) { "Sales Tax" }
+    self.shipping_calculator = ->(order) { order.shipment_total }
     self.shipping_tax_label_maker = ->(shipment, shipping_tax) { "Sales Tax" }
     self.taxable_address_check = ->(address) { true }
     self.test_mode = false

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -29,7 +29,7 @@ module SuperGood
               transaction_id: order.number,
               transaction_date: order.completed_at.to_formatted_s(:iso8601),
               amount: order.total - order.additional_tax_total,
-              shipping: order.shipment_total,
+              shipping: shipping(order),
               sales_tax: order.additional_tax_total
             )
         end
@@ -93,6 +93,10 @@ module SuperGood
 
         def discount(line_item)
           ::SuperGood::SolidusTaxJar.discount_calculator.new(line_item).discount
+        end
+
+        def shipping(order)
+          SuperGood::SolidusTaxJar.shipping_calculator.(order)
         end
       end
     end


### PR DESCRIPTION
Necessary if you need to factor in order level adjustments (boooooo)
into your shipping amounts to make things add up correctly.