### PR TITLE
Avoid sending negative order totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Avoid sending negative amounts for order totals.
+
 ## v0.11.0
 
 - Avoid sending 0 quantity line items. TaxJar doesn't like them.

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -28,7 +28,7 @@ module SuperGood
             .merge(
               transaction_id: order.number,
               transaction_date: order.completed_at.to_formatted_s(:iso8601),
-              amount: order.total - order.additional_tax_total,
+              amount: [order.total - order.additional_tax_total, 0].max,
               shipping: shipping(order),
               sales_tax: order.additional_tax_total
             )

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SuperGood::SolidusTaxJar::APIParams do
   let(:order) do
     Spree::Order.create!(
       number: "R111222333",
-      total: BigDecimal("123.45"),
+      total: order_total,
       shipment_total: BigDecimal("3.01"),
       additional_tax_total: BigDecimal("9.87"),
       item_total: BigDecimal("28.00"),
@@ -15,6 +15,7 @@ RSpec.describe SuperGood::SolidusTaxJar::APIParams do
       order.update! completed_at: DateTime.new(2018, 3, 6, 12, 10, 33)
     end
   end
+  let(:order_total) { BigDecimal("123.45") }
 
   let(:store) do
     Spree::Store.create!(
@@ -209,6 +210,14 @@ RSpec.describe SuperGood::SolidusTaxJar::APIParams do
          sales_tax: 4
        }]
       })
+    end
+
+    context "when the order is adjusted to 0" do
+      let(:order_total) { BigDecimal("0") }
+
+      it "sends the order total as zero" do
+        expect(subject[:amount]).to be_zero
+      end
     end
 
     context "when the line item has 0 quantity" do


### PR DESCRIPTION
If an order is adjusted to zero, we don't want to subtract the tax from
it... because that don't make no sense.

A better solution that properly factors in order level adjustments will
be coming eventually, this is just a hack to process some orders
immediately.