### PR TITLE
Remove unnecessary errors when validating address without country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master
+- Fix `#incomplete_address?` method to be friendly also to completely blank addresses.
 
 - Added `SuperGood::SolidusTaxJar::TaxRateCalculator` for retrieving the tax rate for a given `Spree::Address`. The calculator follows `TaxCalculator` conventions by relying on address validators and custom exception handling.
 

--- a/lib/super_good/solidus_taxjar/calculator_helper.rb
+++ b/lib/super_good/solidus_taxjar/calculator_helper.rb
@@ -17,7 +17,7 @@ module SuperGood
           address.city,
           address&.state&.abbr || address.state_name,
           address.zipcode,
-          address.country.iso
+          address.country&.iso
         ].any?(&:blank?)
       end
 

--- a/lib/super_good/solidus_taxjar/calculator_helper.rb
+++ b/lib/super_good/solidus_taxjar/calculator_helper.rb
@@ -15,7 +15,7 @@ module SuperGood
         [
           address.address1,
           address.city,
-          address&.state&.abbr || address.state_name,
+          address.state&.abbr || address.state_name,
           address.zipcode,
           address.country&.iso
         ].any?(&:blank?)

--- a/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
 
     let(:dummy_tax_rate) { BigDecimal(0) }
 
+    let(:empty_address) do
+      ::Spree::Address.new
+    end
+
     let(:incomplete_address) do
       ::Spree::Address.new(
         first_name: "Ronnie James",
@@ -32,6 +36,21 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
 
     shared_examples "returns the dummy tax rate" do
       it { expect(subject).to eq dummy_tax_rate }
+    end
+
+    context "when the address is an empty address" do
+      let(:address) { empty_address }
+
+      context "when we're not rescuing from errors" do
+        around do |example|
+          handler = SuperGood::SolidusTaxJar.exception_handler
+          SuperGood::SolidusTaxJar.exception_handler = -> (error) { raise error }
+          example.run
+          SuperGood::SolidusTaxJar.exception_handler = handler
+        end
+
+        it_behaves_like "returns the dummy tax rate"
+      end
     end
 
     context "when the address is not complete" do


### PR DESCRIPTION
When validating addresses, it may happen that the address has no country, so trying to fetch the country ISO raises an unnecessary error. Using ruby safe navigation prevents this to happen. 

Of course, the address will still result invalid eventually.

This has the extra benefit of avoiding unnecessary error reports to services such as Honeybadger.