### PR TITLE
Use shipping_calculator lambda for order shipping param

### DIFF
--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -7,7 +7,7 @@ module SuperGood
             .merge(customer_params(order))
             .merge(order_address_params(order.tax_address))
             .merge(line_items_params(order.line_items))
-            .merge(shipping: order.shipment_total)
+            .merge(shipping: shipping(order))
             .merge(SuperGood::SolidusTaxJar.custom_order_params.(order))
             .tap do |params|
               next unless SuperGood::SolidusTaxJar.logging_enabled


### PR DESCRIPTION
`APIParams#order_params` should use the `shipping_calculator` lambda instead of a hardcoded value for providing shipping costs to TaxJar.