### PR TITLE
Fix handling of no results for address validation

### DIFF
--- a/lib/super_good/solidus_taxjar/addresses.rb
+++ b/lib/super_good/solidus_taxjar/addresses.rb
@@ -47,6 +47,8 @@ module SuperGood
 
       def taxjar_addresses(spree_address)
         api.validate_spree_address(spree_address)
+      rescue Taxjar::Error::NotFound
+        []
       end
 
       def us

--- a/spec/super_good/solidus_taxjar/addresses_spec.rb
+++ b/spec/super_good/solidus_taxjar/addresses_spec.rb
@@ -41,20 +41,25 @@ RSpec.describe SuperGood::SolidusTaxJar::Addresses do
       instance_double ::SuperGood::SolidusTaxJar::API
     }
 
-    before do
-      allow(dummy_api)
-        .to receive(:validate_spree_address)
-        .with(spree_address)
-        .and_return(results)
-    end
-
     context "when there are no possibilities for the address" do
-      let(:results) { [] }
+      before do
+        allow(dummy_api)
+          .to receive(:validate_spree_address)
+          .with(spree_address)
+          .and_raise(Taxjar::Error::NotFound)
+      end
 
       it { is_expected.to be_nil }
     end
 
     context "when there is one possibility for the address" do
+      before do
+        allow(dummy_api)
+          .to receive(:validate_spree_address)
+          .with(spree_address)
+          .and_return(results)
+      end
+
       let(:results) {
         [
           Taxjar::Address.new(
@@ -85,6 +90,13 @@ RSpec.describe SuperGood::SolidusTaxJar::Addresses do
     end
 
     context "when there are multiple possibilities for the address" do
+      before do
+        allow(dummy_api)
+          .to receive(:validate_spree_address)
+          .with(spree_address)
+          .and_return(results)
+      end
+
       let(:results) {
         [
           Taxjar::Address.new(
@@ -162,20 +174,25 @@ RSpec.describe SuperGood::SolidusTaxJar::Addresses do
       instance_double ::SuperGood::SolidusTaxJar::API
     }
 
-    before do
-      allow(dummy_api)
-        .to receive(:validate_spree_address)
-        .with(spree_address)
-        .and_return(results)
-    end
-
     context "when there are no possibilities for the address" do
-      let(:results) { [] }
+      before do
+        allow(dummy_api)
+          .to receive(:validate_spree_address)
+          .with(spree_address)
+          .and_raise(Taxjar::Error::NotFound)
+      end
 
       it { is_expected.to be_empty }
     end
 
     context "when there is one possibility for the address" do
+      before do
+        allow(dummy_api)
+          .to receive(:validate_spree_address)
+          .with(spree_address)
+          .and_return(results)
+      end
+
       let(:results) {
         [
           Taxjar::Address.new(
@@ -206,6 +223,13 @@ RSpec.describe SuperGood::SolidusTaxJar::Addresses do
     end
 
     context "when there are multiple possibilities for the address" do
+      before do
+        allow(dummy_api)
+          .to receive(:validate_spree_address)
+          .with(spree_address)
+          .and_return(results)
+      end
+
       let(:results) {
         [
           Taxjar::Address.new(


### PR DESCRIPTION
According to [the documentation](https://developers.taxjar.com/api/reference/#post-validate-an-address), and some testing, the API will raise a `Taxjar::Error::NotFound` error if the API finds no addresses. 

Instead of raising this error to others, we should handle it ourselves and return nil/an empty array like we originally intended.

