### PR TITLE
Update extension name

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -25,7 +25,7 @@ else
   BRANCH="master"
 fi
 
-extension_name="solidus_taxjar"
+extension_name="super_good-solidus_taxjar"
 
 # Stay away from the bundler env of the containing extension.
 function unbundled {


### PR DESCRIPTION
Without this update, the following would fail:
$ bundle exec rake sandbox