### PR TITLE
Allow price to be configurable via a line_item method. 

### DIFF
--- a/lib/spree/models/line_item_decorator.rb
+++ b/lib/spree/models/line_item_decorator.rb
@@ -1,0 +1,11 @@
+module Spree
+  module LineItemDecorator
+    protected
+
+    def unit_price
+      price
+    end
+
+    ::Spree::LineItem.prepend self
+  end
+end

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -100,7 +100,7 @@ module SuperGood
               {
                 id: line_item.id,
                 quantity: line_item.quantity,
-                unit_price: line_item.price,
+                unit_price: line_item.unit_price,
                 discount: discount(line_item),
                 product_tax_code: line_item.tax_category&.tax_code
               }


### PR DESCRIPTION
This allows stores that dont follow the traditional price / quantity = amount calculation to set their own unit_price.