### PR TITLE
Include API version in request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#21](https://github.com/SuperGoodSoft/solidus_taxjar/pull/21) Migrated project to `solidus_dev_support`
 - [#22](https://github.com/SuperGoodSoft/solidus_taxjar/pull/22) Added support for TaxJar address validation API through `SuperGood::SolidusTaxJar::Addresses` class
+- [#34](https://github.com/SuperGoodSoft/solidus_taxjar/pull/34) Include API version in request headers
 
 ## v0.17.1
 

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -5,7 +5,9 @@ module SuperGood
         ::Taxjar::Client.new(
           api_key: ENV.fetch("TAXJAR_API_KEY"),
           api_url: ENV.fetch("TAXJAR_API_URL") { "https://api.taxjar.com" } # Sandbox URL: https://api.sandbox.taxjar.com
-        )
+        ).set_api_config('headers', {
+          'x-api-version' => '2020-08-07'
+        })
       end
 
       def initialize(taxjar_client: self.class.default_taxjar_client)

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -1,6 +1,23 @@
 require "spec_helper"
 
 RSpec.describe SuperGood::SolidusTaxJar::API do
+  describe ".new" do
+    subject { described_class.new }
+
+    let(:dummy_client) { instance_double ::Taxjar::Client }
+
+    before do
+      ENV["TAXJAR_API_KEY"] = 'taxjar_api_token'
+    end
+
+    it "puts the API version in the header" do
+      expect_any_instance_of(::Taxjar::Client).to receive(:set_api_config).with('headers', {
+        'x-api-version' => '2020-08-07'
+      })
+      subject
+    end
+  end
+
   describe "#tax_for" do
     subject { api.tax_for order }
 


### PR DESCRIPTION
This is the first pull request to get this extension ready for certification with TaxJar (there will be an issue/milestone to track this process in the future).

TaxJar requires certified extensions to include an API version in the header of each request.

Closes #33.