### PR TITLE
Add basic UI for Taxjar settings in solidus admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#58](https://github.com/SuperGoodSoft/solidus_taxjar/pull/58) Take shipping promotions into account in default calculator
 - [#59](https://github.com/SuperGoodSoft/solidus_taxjar/pull/59) Add pry debugging tools
 - [#69](https://github.com/SuperGoodSoft/solidus_taxjar/pull/69) Lock ExecJS version
+- [#37](https://github.com/SuperGoodSoft/solidus_taxjar/pull/37) Added a basic Taxjar settings admin interface which displays placeholder text.
 
 ## v0.18.1
 

--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -1,0 +1,8 @@
+module Spree
+  module Admin
+    class TaxjarSettingsController < Spree::Admin::BaseController
+      def show
+      end
+    end
+  end
+end

--- a/app/overrides/spree/admin/shared/_configuration_menu.rb
+++ b/app/overrides/spree/admin/shared/_configuration_menu.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  virtual_path: 'spree/admin/shared/_taxes_tabs',
+  name: 'add_taxjar_admin_menu_links',
+  insert_bottom: "[data-hook='admin_settings_taxes_tabs']"
+) do
+  <<-HTML
+    <%= configurations_sidebar_menu_item "TaxJar Settings", admin_taxjar_settings_path %>
+  HTML
+end

--- a/app/views/spree/admin/taxjar_settings/show.html.erb
+++ b/app/views/spree/admin/taxjar_settings/show.html.erb
@@ -1,0 +1,12 @@
+<%= render 'spree/admin/shared/taxes_tabs' %>
+
+<% content_for :page_title do %>
+  <%= "Taxjar Settings" %>
+<% end %>
+
+<% if ENV["TAXJAR_API_KEY"] %>
+  <table>
+  </table>
+<% else %>
+  <p>You must provide a TaxJar API token to configure the extension. Please see the extension readme for details.</p>
+<% end %>

--- a/app/views/spree/admin/taxjar_settings/show.html.erb
+++ b/app/views/spree/admin/taxjar_settings/show.html.erb
@@ -8,5 +8,6 @@
   <table>
   </table>
 <% else %>
-  <p>You must provide a TaxJar API token to configure the extension. Please see the extension readme for details.</p>
+  <p>You must provide a TaxJar API token to use this extension. You can sign up for TaxJar <%= link_to "here", "https://app.taxjar.com/api_sign_up", target: "_blank", rel: "noreferrer" %>. Please see the extension documentation for details on providing this token to the extension.</p>
+  <p><i>For more help in aquiring a TaxJar API token, see <%= link_to "How do I get a TaxJar sales tax API token?", "https://support.taxjar.com/article/160-how-do-i-get-a-sales-tax-api-token", target: "_blank", rel: "noreferrer" %></i></p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Spree::Core::Engine.routes.draw do
+  namespace :admin do
+    resource :taxjar_settings, only: [:show]
+  end
+end

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -39,6 +39,9 @@ RSpec.feature 'Admin TaxJar Settings', js: true do
         expect(page).to have_content("TaxJar Settings")
         click_on "TaxJar Settings"
         expect(page).to have_content "You must provide a TaxJar API token"
+
+        expect(page).to have_link(href: "https://app.taxjar.com/api_sign_up")
+        expect(page).to have_link(href: "https://support.taxjar.com/article/160-how-do-i-get-a-sales-tax-api-token")
       end
     end
   end

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.feature 'Admin TaxJar Settings', js: true do
+  stub_authorization!
+
+  background do
+    create :store, default: true
+  end
+
+  describe "Taxjar settings tab" do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("TAXJAR_API_KEY").and_return(api_token)
+    end
+
+    context "Taxjar API token is set" do
+      let(:api_token) { "token" }
+
+      it "shows a blank settings page" do
+
+        visit "/admin"
+        click_on "Settings"
+        expect(page).to have_content("Taxes")
+        click_on "Taxes"
+        expect(page).to have_content("TaxJar Settings")
+        click_on "TaxJar Settings"
+        expect(page).not_to have_content "You must provide a TaxJar API token"
+      end
+    end
+
+    context "Taxjar API token isn't set" do
+      let(:api_token) { nil }
+
+      it "shows a descriptive error message" do
+        visit "/admin"
+        click_on "Settings"
+        expect(page).to have_content("Taxes")
+        click_on "Taxes"
+        expect(page).to have_content("TaxJar Settings")
+        click_on "TaxJar Settings"
+        expect(page).to have_content "You must provide a TaxJar API token"
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require File.expand_path("dummy/config/environment.rb", __dir__).tap { |file|
   system "bin/rake extension:test_app" unless File.exist? file
 }
 
-require "solidus_dev_support/rspec/rails_helper"
+require "solidus_dev_support/rspec/feature_helper"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
     subject { described_class.new }
 
     before do
-      ENV["TAXJAR_API_KEY"] = 'taxjar_api_token'
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("TAXJAR_API_KEY").and_return("taxjar_api_token")
     end
 
     it "sets the correct headers" do
@@ -21,7 +22,8 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
     subject { described_class.default_taxjar_client }
 
     before do
-      ENV["TAXJAR_API_KEY"] = 'taxjar_api_token'
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("TAXJAR_API_KEY").and_return("taxjar_api_token")
     end
 
     it "returns an instance of the TaxJar client" do


### PR DESCRIPTION
This commit adds a tab to the taxes section of the solidus admin settings. 
This provides the foundation for further configuration of Taxjar through the solidus admin.

Right now, the new settings tab does not display any content.

If the API key is not set, the settings tab should just show a descriptive message asking you to provide an API token. This is to conform with the Taxjar certification checklist requirement to hide the Taxjar settings until an API token is provided.

The descriptive messaging also provides links to signup for Taxjar, and a link to help article for acquiring an API token, to comply with certification requirements. 

Manual Tests
----

1. Set a taxjar API key
     * [x] Ensure that you see a blank page in the Taxjar settings tab
1. Don't set a taxjar API key
     * [x] Ensure you see a descriptive message telling you to provide an API key

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

Screenshots
---

<img width="1148" alt="Screen Shot 2021-02-21 at 20 58 44PST" src="https://user-images.githubusercontent.com/8933450/108664478-b28e2880-7487-11eb-9d7a-ecbb31362165.png">

<img width="1326" alt="Screen Shot 2021-02-22 at 13 30 00PST" src="https://user-images.githubusercontent.com/8933450/108772696-32f96b80-7512-11eb-980a-e351a9153a93.png">