### PR TITLE
Add taxjar rails engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#21](https://github.com/SuperGoodSoft/solidus_taxjar/pull/21) Migrated project to `solidus_dev_support`
 - [#22](https://github.com/SuperGoodSoft/solidus_taxjar/pull/22) Added support for TaxJar address validation API through `SuperGood::SolidusTaxJar::Addresses` class
 - [#34](https://github.com/SuperGoodSoft/solidus_taxjar/pull/34) Include API version in request headers
+- [#38](https://github.com/SuperGoodSoft/solidus_taxjar/pull/38) Added a rails engine to support future solidus backend UI
 
 ## v0.17.1
 

--- a/lib/super_good-solidus_taxjar.rb
+++ b/lib/super_good-solidus_taxjar.rb
@@ -1,1 +1,4 @@
+# frozen_string_literal: true
+
 require "super_good/solidus_taxjar"
+require "super_good/engine"

--- a/lib/super_good/engine.rb
+++ b/lib/super_good/engine.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SuperGoodSolidusTaxjar
+  class Engine < Rails::Engine
+    isolate_namespace Spree
+    engine_name 'super_good-solidus_taxjar'
+  end
+end


### PR DESCRIPTION
In order to have the this extension certified by Taxjar, we will need to add significant UI to the solidus backend.

A prerequisite to this is adding a rails engine for Taxjar so components like controllers can be added to the extension and loaded by solidus. 