### PR TITLE
Put plugin name in API request headers

### DIFF
--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -6,7 +6,8 @@ module SuperGood
           api_key: ENV.fetch("TAXJAR_API_KEY"),
           api_url: ENV.fetch("TAXJAR_API_URL") { "https://api.taxjar.com" } # Sandbox URL: https://api.sandbox.taxjar.com
         ).set_api_config('headers', {
-          'x-api-version' => '2020-08-07'
+          'x-api-version' => '2020-08-07',
+          'plugin' => 'supergoodsolidustaxjar'
         })
       end
 

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
       ENV["TAXJAR_API_KEY"] = 'taxjar_api_token'
     end
 
-    it "puts the API version in the header" do
+    it "sets the correct headers" do
       expect_any_instance_of(::Taxjar::Client).to receive(:set_api_config).with('headers', {
-        'x-api-version' => '2020-08-07'
+        'x-api-version' => '2020-08-07',
+        'plugin' => 'supergoodsolidustaxjar'
       })
       subject
     end


### PR DESCRIPTION
To meet Taxjar's certification requirements, we need to supply a 'plugin'
name in each API request header. As such we add this header where the
API version header is supplied.

Closes #35.