### PR TITLE
Support zeitwerk loading (0.18.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ dist: trusty
 sudo: false
 language: ruby
 cache: bundler
+addons:
+  postgresql: "9.3"
 jobs:
   include:
     - rvm: 2.5.8
       env: SOLIDUS_BRANCH=v2.9 DB=postgresql RAILS_VERSION="~> 5.1.0"
     - rvm: 2.6.6
       env: SOLIDUS_BRANCH=v2.10 DB=postgresql RAILS_VERSION="~> 5.2.0"
+    - rvm: 2.6.6
+      env: SOLIDUS_BRANCH=v2.10 DB=postgresql RAILS_VERSION="~> 6.0.0"
+
 before_install:
   - gem update --system
   - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 # Changelog
 
-## master
+## v0.18.0
 
 - [#21](https://github.com/SuperGoodSoft/solidus_taxjar/pull/21) Migrated project to `solidus_dev_support`
 - [#22](https://github.com/SuperGoodSoft/solidus_taxjar/pull/22) Added support for TaxJar address validation API through `SuperGood::SolidusTaxJar::Addresses` class
 - [#34](https://github.com/SuperGoodSoft/solidus_taxjar/pull/34) Include API version in request headers
 - [#38](https://github.com/SuperGoodSoft/solidus_taxjar/pull/38) Added a rails engine to support future solidus backend UI
+- [#43](https://github.com/SuperGoodSoft/solidus_taxjar/pull/43) Support zeitwerk loading
+
+**Breaking Changes**:
+
+- Module name `SolidusTaxJar` renamed to `SolidusTaxjar`
+- Class name `API` renamed to `Api`
+- Class name `APIParams` renamed to `ApiParams`
+
+### Upgrading from 0.17.X to 0.18.X
+
+If you're currently using version 0.17.X and want to upgrade to 0.18.X, follow these steps:
+
+- Rename any instances of the module `SolidusTaxJar` to `SolidusTaxjar`
+- Rename any instances of the class `API` to `Api`
+- Rename any instances of the class `APIParams` to `ApiParams`
 
 ## v0.17.1
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# `SuperGood::SolidusTaxJar` [![Build Status](https://travis-ci.com/SuperGoodSoft/solidus_taxjar.svg?token=rc5QTgHvLLF7cpqkmyfd&branch=master)](https://travis-ci.com/SuperGoodSoft/solidus_taxjar)
+# `SuperGood::SolidusTaxjar` [![Build Status](https://travis-ci.com/SuperGoodSoft/solidus_taxjar.svg?token=rc5QTgHvLLF7cpqkmyfd&branch=master)](https://travis-ci.com/SuperGoodSoft/solidus_taxjar)
 
-`SuperGood::SolidusTaxJar` is a [Solidus](https://github.com/solidusio/solidus) extension that allows Solidus stores to use [TaxJar](https://www.taxjar.com/) for tax calculations.
+`SuperGood::SolidusTaxjar` is a [Solidus](https://github.com/solidusio/solidus) extension that allows Solidus stores to use [TaxJar](https://www.taxjar.com/) for tax calculations.
 
-This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spree_taxjar), like [solidus_taxjar](https://github.com/boomerdigital/solidus_taxjar). Instead of using a custom calculator, `SuperGood::SolidusTaxJar` uses the new configurable tax system [by @adammathys](https://github.com/solidusio/solidus/pull/1892) introduced in Solidus v2.4. This maps better to how the TaxJar API itself works.
+This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spree_taxjar), like [solidus_taxjar](https://github.com/boomerdigital/solidus_taxjar). Instead of using a custom calculator, `SuperGood::SolidusTaxjar` uses the new configurable tax system [by @adammathys](https://github.com/solidusio/solidus/pull/1892) introduced in Solidus v2.4. This maps better to how the TaxJar API itself works.
 
 ## Installation
 
@@ -22,7 +22,7 @@ This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spr
    # Put this in config/initializers/solidus.rb
 
    Spree.config do |config|
-     config.tax_calculator_class = SuperGood::SolidusTaxJar::TaxCalculator
+     config.tax_calculator_class = SuperGood::SolidusTaxjar::TaxCalculator
    end
    ```
 
@@ -31,7 +31,7 @@ This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spr
    ```ruby
    # Put this in config/initializers/taxjar.rb
 
-   SuperGood::SolidusTaxJar.exception_handler = ->(e) {
+   SuperGood::SolidusTaxjar.exception_handler = ->(e) {
      # Report exceptions in here. For example, if you were using the Sentry's
      # raven-ruby gem to report errors, you might do this:
      Raven.capture_exception(e)
@@ -57,11 +57,11 @@ The extension provides currently two high level `calculator` classes that wrap t
 
 ### TaxCalculator
 
-`SuperGood::SolidusTaxJar::TaxCalculator` allows calculating the full tax breakdown for a given `Spree::Order`. The breakdown includes separate line items taxes and shipment taxes.
+`SuperGood::SolidusTaxjar::TaxCalculator` allows calculating the full tax breakdown for a given `Spree::Order`. The breakdown includes separate line items taxes and shipment taxes.
 
 ### TaxRateCalculator
 
-`SuperGood::SolidusTaxJar::TaxRateCalculator` allows calculating the tax rate for a given `Spree::Address`. It relies on the same low-level Ruby TaxJar API endpoint of the tax calculator in order to provide the most coherent and reliable results. TaxJar support recommends using this endpoint for live calculations.
+`SuperGood::SolidusTaxjar::TaxRateCalculator` allows calculating the tax rate for a given `Spree::Address`. It relies on the same low-level Ruby TaxJar API endpoint of the tax calculator in order to provide the most coherent and reliable results. TaxJar support recommends using this endpoint for live calculations.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spr
 
        $ bundle
 
-2. Next, configure Solidus to use this gem:
+2. Install and run the necessary migrations:
+
+   ```shell
+   bundle exec rails g super_good:solidus_taxjar:install
+   bundle exec rake db:migrate
+   ```
+
+3. Next, configure Solidus to use this gem:
 
    ```ruby
    # Put this in config/initializers/solidus.rb
@@ -26,7 +33,7 @@ This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spr
    end
    ```
 
-3. Also, configure your error handling:
+4. Also, configure your error handling:
 
    ```ruby
    # Put this in config/initializers/taxjar.rb
@@ -38,7 +45,7 @@ This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spr
    }
    ```
 
-4. Finally, make sure that the `TAXJAR_API_KEY` environment variable is set to a your TaxJar API key and make sure that you have a `Spree::TaxRate` with the name "Sales Tax". This will be used as the source for the tax adjustments that Solidus creates.
+5. Finally, make sure that the `TAXJAR_API_KEY` environment variable is set to a your TaxJar API key and make sure that you have a `Spree::TaxRate` with the name "Sales Tax". This will be used as the source for the tax adjustments that Solidus creates.
 
 ## Project Status
 

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -28,14 +28,14 @@ module SuperGood
       attr_accessor :test_mode
 
       def api
-        ::SuperGood::SolidusTaxjar::API.new
+        ::SuperGood::SolidusTaxjar::Api.new
       end
     end
 
     self.cache_duration = 3.hours
     self.cache_key = ->(record) {
       record_type = record.class.name.demodulize.underscore
-      APIParams.send("#{record_type}_params", record).to_json
+      ApiParams.send("#{record_type}_params", record).to_json
     }
     self.custom_order_params = ->(order) { {} }
     self.discount_calculator = ::SuperGood::SolidusTaxjar::DiscountCalculator

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -12,7 +12,7 @@ require "super_good/solidus_taxjar/discount_calculator"
 require "super_good/solidus_taxjar/addresses"
 
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     class << self
       attr_accessor :cache_duration
       attr_accessor :cache_key
@@ -28,7 +28,7 @@ module SuperGood
       attr_accessor :test_mode
 
       def api
-        ::SuperGood::SolidusTaxJar::API.new
+        ::SuperGood::SolidusTaxjar::API.new
       end
     end
 
@@ -38,7 +38,7 @@ module SuperGood
       APIParams.send("#{record_type}_params", record).to_json
     }
     self.custom_order_params = ->(order) { {} }
-    self.discount_calculator = ::SuperGood::SolidusTaxJar::DiscountCalculator
+    self.discount_calculator = ::SuperGood::SolidusTaxjar::DiscountCalculator
     self.exception_handler = ->(e) {
       Rails.logger.error "An error occurred while fetching TaxJar tax rates - #{e}: #{e.message}"
     }

--- a/lib/super_good/solidus_taxjar/addresses.rb
+++ b/lib/super_good/solidus_taxjar/addresses.rb
@@ -1,5 +1,5 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     class Addresses
       class << self
         def normalize(spree_address)
@@ -11,7 +11,7 @@ module SuperGood
         end
       end
 
-      def initialize(api: ::SuperGood::SolidusTaxJar.api)
+      def initialize(api: ::SuperGood::SolidusTaxjar.api)
         @api = api
       end
 

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -1,5 +1,5 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     class API
       def self.default_taxjar_client
         ::Taxjar::Client.new(
@@ -17,7 +17,7 @@ module SuperGood
 
       def tax_for(order)
         taxjar_client.tax_for_order(APIParams.order_params(order)).tap do |taxes|
-          next unless SuperGood::SolidusTaxJar.logging_enabled
+          next unless SuperGood::SolidusTaxjar.logging_enabled
 
           Rails.logger.info(
             "TaxJar response for #{order.number}: #{taxes.to_h.inspect}"

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -1,6 +1,6 @@
 module SuperGood
   module SolidusTaxjar
-    class API
+    class Api
       def self.default_taxjar_client
         ::Taxjar::Client.new(
           api_key: ENV.fetch("TAXJAR_API_KEY"),
@@ -16,7 +16,7 @@ module SuperGood
       end
 
       def tax_for(order)
-        taxjar_client.tax_for_order(APIParams.order_params(order)).tap do |taxes|
+        taxjar_client.tax_for_order(ApiParams.order_params(order)).tap do |taxes|
           next unless SuperGood::SolidusTaxjar.logging_enabled
 
           Rails.logger.info(
@@ -26,19 +26,19 @@ module SuperGood
       end
 
       def tax_rate_for(address)
-        taxjar_client.tax_for_order(APIParams.tax_rate_address_params(address)).rate
+        taxjar_client.tax_for_order(ApiParams.tax_rate_address_params(address)).rate
       end
 
       def tax_rates_for(address)
-        taxjar_client.rates_for_location(*APIParams.address_params(address))
+        taxjar_client.rates_for_location(*ApiParams.address_params(address))
       end
 
       def create_transaction_for(order)
-        taxjar_client.create_order APIParams.transaction_params(order)
+        taxjar_client.create_order ApiParams.transaction_params(order)
       end
 
       def update_transaction_for(order)
-        taxjar_client.update_order APIParams.transaction_params(order)
+        taxjar_client.update_order ApiParams.transaction_params(order)
       end
 
       def delete_transaction_for(order)
@@ -46,11 +46,11 @@ module SuperGood
       end
 
       def create_refund_for(reimbursement)
-        taxjar_client.create_refund APIParams.refund_params(reimbursement)
+        taxjar_client.create_refund ApiParams.refund_params(reimbursement)
       end
 
       def validate_spree_address(spree_address)
-        taxjar_client.validate_address APIParams.validate_address_params(spree_address)
+        taxjar_client.validate_address ApiParams.validate_address_params(spree_address)
       end
 
       private

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -1,6 +1,6 @@
 module SuperGood
   module SolidusTaxjar
-    module APIParams
+    module ApiParams
       class << self
         def order_params(order)
           {}

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -1,5 +1,5 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     module APIParams
       class << self
         def order_params(order)
@@ -8,9 +8,9 @@ module SuperGood
             .merge(order_address_params(order.tax_address))
             .merge(line_items_params(order.line_items))
             .merge(shipping: shipping(order))
-            .merge(SuperGood::SolidusTaxJar.custom_order_params.call(order))
+            .merge(SuperGood::SolidusTaxjar.custom_order_params.call(order))
             .tap do |params|
-              next unless SuperGood::SolidusTaxJar.logging_enabled
+              next unless SuperGood::SolidusTaxjar.logging_enabled
 
               Rails.logger.info(
                 "TaxJar params for #{order.number}: #{params.inspect}"
@@ -133,11 +133,11 @@ module SuperGood
         end
 
         def discount(line_item)
-          ::SuperGood::SolidusTaxJar.discount_calculator.new(line_item).discount
+          ::SuperGood::SolidusTaxjar.discount_calculator.new(line_item).discount
         end
 
         def shipping(order)
-          SuperGood::SolidusTaxJar.shipping_calculator.call(order)
+          SuperGood::SolidusTaxjar.shipping_calculator.call(order)
         end
 
         def sales_tax(order)

--- a/lib/super_good/solidus_taxjar/calculator_helper.rb
+++ b/lib/super_good/solidus_taxjar/calculator_helper.rb
@@ -1,5 +1,5 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     module CalculatorHelper
       extend ActiveSupport::Concern
 
@@ -16,14 +16,14 @@ module SuperGood
       end
 
       def taxable_address?(address)
-        SuperGood::SolidusTaxJar.taxable_address_check.call(address)
+        SuperGood::SolidusTaxjar.taxable_address_check.call(address)
       end
 
       def cache
         if !Rails.env.test?
           Rails.cache.fetch(
             cache_key,
-            expires_in: SuperGood::SolidusTaxJar.cache_duration
+            expires_in: SuperGood::SolidusTaxjar.cache_duration
           ) { yield }
         else
           yield
@@ -31,7 +31,7 @@ module SuperGood
       end
 
       def exception_handler
-        SuperGood::SolidusTaxJar.exception_handler
+        SuperGood::SolidusTaxjar.exception_handler
       end
     end
   end

--- a/lib/super_good/solidus_taxjar/discount_calculator.rb
+++ b/lib/super_good/solidus_taxjar/discount_calculator.rb
@@ -1,5 +1,5 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     class DiscountCalculator
       def initialize(line_item)
         @line_item = line_item

--- a/lib/super_good/solidus_taxjar/tax_calculator.rb
+++ b/lib/super_good/solidus_taxjar/tax_calculator.rb
@@ -1,15 +1,15 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     class TaxCalculator
       include CalculatorHelper
 
-      def initialize(order, api: SuperGood::SolidusTaxJar.api)
+      def initialize(order, api: SuperGood::SolidusTaxjar.api)
         @order = order
         @api = api
       end
 
       def calculate
-        return no_tax if SuperGood::SolidusTaxJar.test_mode
+        return no_tax if SuperGood::SolidusTaxjar.test_mode
         return no_tax if incomplete_address?(order.tax_address) || order.line_items.none?
         return no_tax unless taxable_order? order
         return no_tax unless taxable_address? order.tax_address
@@ -114,22 +114,22 @@ module SuperGood
       end
 
       def cache_key
-        SuperGood::SolidusTaxJar.cache_key.call(order)
+        SuperGood::SolidusTaxjar.cache_key.call(order)
       end
 
       def taxable_order?(order)
-        SuperGood::SolidusTaxJar.taxable_order_check.call(order)
+        SuperGood::SolidusTaxjar.taxable_order_check.call(order)
       end
 
       def shipping_tax_label(shipment, shipping_tax)
-        SuperGood::SolidusTaxJar.shipping_tax_label_maker.call(
+        SuperGood::SolidusTaxjar.shipping_tax_label_maker.call(
           shipment,
           shipping_tax
         )
       end
 
       def line_item_tax_label(taxjar_line_item, spree_line_item)
-        SuperGood::SolidusTaxJar.line_item_tax_label_maker.call(taxjar_line_item, spree_line_item)
+        SuperGood::SolidusTaxjar.line_item_tax_label_maker.call(taxjar_line_item, spree_line_item)
       end
     end
   end

--- a/lib/super_good/solidus_taxjar/tax_rate_calculator.rb
+++ b/lib/super_good/solidus_taxjar/tax_rate_calculator.rb
@@ -1,14 +1,14 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     class TaxRateCalculator
       include CalculatorHelper
-      def initialize(address, api: SuperGood::SolidusTaxJar.api)
+      def initialize(address, api: SuperGood::SolidusTaxjar.api)
         @address = address
         @api = api
       end
 
       def calculate
-        return no_rate if SuperGood::SolidusTaxJar.test_mode
+        return no_rate if SuperGood::SolidusTaxjar.test_mode
         return no_rate if incomplete_address?(address)
         return no_rate unless taxable_address?(address)
         cache do
@@ -28,7 +28,7 @@ module SuperGood
       end
 
       def cache_key
-        SuperGood::SolidusTaxJar.cache_key.call(address)
+        SuperGood::SolidusTaxjar.cache_key.call(address)
       end
     end
   end

--- a/lib/super_good/solidus_taxjar/version.rb
+++ b/lib/super_good/solidus_taxjar/version.rb
@@ -1,5 +1,5 @@
 module SuperGood
-  module SolidusTaxJar
+  module SolidusTaxjar
     VERSION = "0.17.1"
   end
 end

--- a/lib/super_good/solidus_taxjar/version.rb
+++ b/lib/super_good/solidus_taxjar/version.rb
@@ -1,5 +1,5 @@
 module SuperGood
   module SolidusTaxjar
-    VERSION = "0.17.1"
+    VERSION = "0.18.0"
   end
 end

--- a/spec/super_good/solidus_taxjar/addresses_spec.rb
+++ b/spec/super_good/solidus_taxjar/addresses_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
     }
 
     let(:dummy_api) {
-      instance_double ::SuperGood::SolidusTaxjar::API
+      instance_double ::SuperGood::SolidusTaxjar::Api
     }
 
     context "when there are no possibilities for the address" do
@@ -171,7 +171,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
     }
 
     let(:dummy_api) {
-      instance_double ::SuperGood::SolidusTaxjar::API
+      instance_double ::SuperGood::SolidusTaxjar::Api
     }
 
     context "when there are no possibilities for the address" do

--- a/spec/super_good/solidus_taxjar/addresses_spec.rb
+++ b/spec/super_good/solidus_taxjar/addresses_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxJar::Addresses do
+RSpec.describe SuperGood::SolidusTaxjar::Addresses do
   describe "#normalize" do
     subject { described_class.new(api: dummy_api).normalize(spree_address) }
 
@@ -38,7 +38,7 @@ RSpec.describe SuperGood::SolidusTaxJar::Addresses do
     }
 
     let(:dummy_api) {
-      instance_double ::SuperGood::SolidusTaxJar::API
+      instance_double ::SuperGood::SolidusTaxjar::API
     }
 
     context "when there are no possibilities for the address" do
@@ -171,7 +171,7 @@ RSpec.describe SuperGood::SolidusTaxJar::Addresses do
     }
 
     let(:dummy_api) {
-      instance_double ::SuperGood::SolidusTaxJar::API
+      instance_double ::SuperGood::SolidusTaxjar::API
     }
 
     context "when there are no possibilities for the address" do

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxjar::APIParams do
+RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
   let(:order) do
     Spree::Order.create!(
       additional_tax_total: BigDecimal("9.87"),

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxJar::APIParams do
+RSpec.describe SuperGood::SolidusTaxjar::APIParams do
   let(:order) do
     Spree::Order.create!(
       additional_tax_total: BigDecimal("9.87"),
@@ -143,8 +143,8 @@ RSpec.describe SuperGood::SolidusTaxJar::APIParams do
 
     context "when custom params are used" do
       around do |example|
-        default = SuperGood::SolidusTaxJar.custom_order_params
-        SuperGood::SolidusTaxJar.custom_order_params = ->(order) {
+        default = SuperGood::SolidusTaxjar.custom_order_params
+        SuperGood::SolidusTaxjar.custom_order_params = ->(order) {
           {
             nexus_addresses: [
               {
@@ -158,7 +158,7 @@ RSpec.describe SuperGood::SolidusTaxJar::APIParams do
           }
         }
         example.run
-        SuperGood::SolidusTaxJar.custom_order_params = default
+        SuperGood::SolidusTaxjar.custom_order_params = default
       end
 
       it "returns params for fetching the tax for the order" do

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxjar::API do
+RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe ".new" do
     subject { described_class.new }
 
@@ -27,7 +27,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:order) { Spree::Order.new }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:order_params)
         .with(order)
         .and_return({order: "params"})
@@ -51,7 +51,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:response) { double(rate: tax_rate) }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:tax_rate_address_params)
         .with(address)
         .and_return({address: "params"})
@@ -73,7 +73,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:address) { Spree::Address.new }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:address_params)
         .with(address)
         .and_return(["zipcode", {address: "params"}])
@@ -95,7 +95,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:order) { Spree::Order.new }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:transaction_params)
         .with(order)
         .and_return({transaction: "params"})
@@ -117,7 +117,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:order) { Spree::Order.new }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:transaction_params)
         .with(order)
         .and_return({transaction: "params"})
@@ -156,7 +156,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:reimbursement) { Spree::Reimbursement.new }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:refund_params)
         .with(reimbursement)
         .and_return({refund: "params"})
@@ -178,7 +178,7 @@ RSpec.describe SuperGood::SolidusTaxjar::API do
     let(:spree_address) { build :address }
 
     before do
-      allow(SuperGood::SolidusTaxjar::APIParams)
+      allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:validate_address_params)
         .with(spree_address)
         .and_return({address: "params"})

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxJar::API do
+RSpec.describe SuperGood::SolidusTaxjar::API do
   describe ".new" do
     subject { described_class.new }
 
@@ -27,7 +27,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:order) { Spree::Order.new }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:order_params)
         .with(order)
         .and_return({order: "params"})
@@ -51,7 +51,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:response) { double(rate: tax_rate) }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:tax_rate_address_params)
         .with(address)
         .and_return({address: "params"})
@@ -73,7 +73,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:address) { Spree::Address.new }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:address_params)
         .with(address)
         .and_return(["zipcode", {address: "params"}])
@@ -95,7 +95,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:order) { Spree::Order.new }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:transaction_params)
         .with(order)
         .and_return({transaction: "params"})
@@ -117,7 +117,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:order) { Spree::Order.new }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:transaction_params)
         .with(order)
         .and_return({transaction: "params"})
@@ -156,7 +156,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:reimbursement) { Spree::Reimbursement.new }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:refund_params)
         .with(reimbursement)
         .and_return({refund: "params"})
@@ -178,7 +178,7 @@ RSpec.describe SuperGood::SolidusTaxJar::API do
     let(:spree_address) { build :address }
 
     before do
-      allow(SuperGood::SolidusTaxJar::APIParams)
+      allow(SuperGood::SolidusTaxjar::APIParams)
         .to receive(:validate_address_params)
         .with(spree_address)
         .and_return({address: "params"})

--- a/spec/super_good/solidus_taxjar/discount_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/discount_calculator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxJar::DiscountCalculator do
+RSpec.describe SuperGood::SolidusTaxjar::DiscountCalculator do
   describe "#discount" do
     subject { calculator.discount }
 

--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
     let(:calculator) { described_class.new(order, api: dummy_api) }
 
     let(:dummy_api) do
-      instance_double ::SuperGood::SolidusTaxjar::API
+      instance_double ::SuperGood::SolidusTaxjar::Api
     end
 
     let(:order) do

--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
-RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
+RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
   describe "#calculate" do
     subject { calculator.calculate }
 
     let(:calculator) { described_class.new(order, api: dummy_api) }
 
     let(:dummy_api) do
-      instance_double ::SuperGood::SolidusTaxJar::API
+      instance_double ::SuperGood::SolidusTaxjar::API
     end
 
     let(:order) do
@@ -141,7 +141,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
       end
 
       it "calls the configured error handler" do
-        expect(SuperGood::SolidusTaxJar.exception_handler).to receive(:call) do |e|
+        expect(SuperGood::SolidusTaxjar.exception_handler).to receive(:call) do |e|
           expect(e).to be_a StandardError
           expect(e.message).to eq "A bad thing happened."
         end
@@ -217,7 +217,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
 
         context "with custom line item tax labels" do
           before do
-            allow(SuperGood::SolidusTaxJar.line_item_tax_label_maker)
+            allow(SuperGood::SolidusTaxjar.line_item_tax_label_maker)
               .to receive(:call)
               .with(taxjar_line_item, line_items.first)
               .and_return("Space Tax")
@@ -231,7 +231,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
 
         context "but the taxable address check returns false" do
           before do
-            allow(SuperGood::SolidusTaxJar.taxable_address_check)
+            allow(SuperGood::SolidusTaxjar.taxable_address_check)
               .to receive(:call).with(address)
               .and_return(false)
           end
@@ -245,7 +245,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
 
         context "but the taxable order check returns false" do
           before do
-            allow(SuperGood::SolidusTaxJar.taxable_order_check)
+            allow(SuperGood::SolidusTaxjar.taxable_order_check)
               .to receive(:call).with(order)
               .and_return(false)
           end
@@ -289,7 +289,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
 
           context "with custom shipping tax labels" do
             before do
-              allow(SuperGood::SolidusTaxJar.shipping_tax_label_maker).to receive(:call)
+              allow(SuperGood::SolidusTaxjar.shipping_tax_label_maker).to receive(:call)
                 .and_return("Magic Tax", "Spicy Tax", "Vegetable Tax")
             end
 
@@ -307,8 +307,8 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxCalculator do
         end
 
         context "when test_mode is set" do
-          before { SuperGood::SolidusTaxJar.test_mode = true }
-          after { SuperGood::SolidusTaxJar.test_mode = false }
+          before { SuperGood::SolidusTaxjar.test_mode = true }
+          after { SuperGood::SolidusTaxjar.test_mode = false }
 
           it "returns no taxes" do
             expect(subject.order_id).to eq order.id

--- a/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxRateCalculator do
     let(:calculator) { described_class.new(address, api: dummy_api) }
 
     let(:dummy_api) do
-      instance_double ::SuperGood::SolidusTaxjar::API
+      instance_double ::SuperGood::SolidusTaxjar::Api
     end
 
     let(:dummy_tax_rate) { BigDecimal(0) }

--- a/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
-RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
+RSpec.describe ::SuperGood::SolidusTaxjar::TaxRateCalculator do
   describe "#calculate" do
     subject { calculator.calculate }
 
     let(:calculator) { described_class.new(address, api: dummy_api) }
 
     let(:dummy_api) do
-      instance_double ::SuperGood::SolidusTaxJar::API
+      instance_double ::SuperGood::SolidusTaxjar::API
     end
 
     let(:dummy_tax_rate) { BigDecimal(0) }
@@ -43,10 +43,10 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
 
       context "when we're not rescuing from errors" do
         around do |example|
-          handler = SuperGood::SolidusTaxJar.exception_handler
-          SuperGood::SolidusTaxJar.exception_handler = ->(error) { raise error }
+          handler = SuperGood::SolidusTaxjar.exception_handler
+          SuperGood::SolidusTaxjar.exception_handler = ->(error) { raise error }
           example.run
-          SuperGood::SolidusTaxJar.exception_handler = handler
+          SuperGood::SolidusTaxjar.exception_handler = handler
         end
 
         it_behaves_like "returns the dummy tax rate"
@@ -64,7 +64,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
 
       context "when the address is not taxable" do
         before do
-          allow(SuperGood::SolidusTaxJar.taxable_address_check)
+          allow(SuperGood::SolidusTaxjar.taxable_address_check)
             .to receive(:call).with(address)
             .and_return(false)
         end
@@ -93,7 +93,7 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
       end
 
       it "calls the configured error handler" do
-        expect(SuperGood::SolidusTaxJar.exception_handler).to receive(:call) do |e|
+        expect(SuperGood::SolidusTaxjar.exception_handler).to receive(:call) do |e|
           expect(e).to be_a StandardError
           expect(e.message).to eq "A bad thing happened."
         end
@@ -107,8 +107,8 @@ RSpec.describe ::SuperGood::SolidusTaxJar::TaxRateCalculator do
     context "when test_mode is set" do
       let(:address) { complete_address }
 
-      before { SuperGood::SolidusTaxJar.test_mode = true }
-      after { SuperGood::SolidusTaxJar.test_mode = false }
+      before { SuperGood::SolidusTaxjar.test_mode = true }
+      after { SuperGood::SolidusTaxjar.test_mode = false }
 
       it_behaves_like "returns the dummy tax rate"
     end

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
-RSpec.describe SuperGood::SolidusTaxJar do
+RSpec.describe SuperGood::SolidusTaxjar do
   it "has a version number" do
-    expect(SuperGood::SolidusTaxJar::VERSION).not_to be nil
+    expect(SuperGood::SolidusTaxjar::VERSION).not_to be nil
   end
 
   describe "configuration" do
@@ -12,7 +12,7 @@ RSpec.describe SuperGood::SolidusTaxJar do
       let(:order) { Spree::Order.new }
 
       it "returns the API params converted to JSON" do
-        allow(SuperGood::SolidusTaxJar::APIParams)
+        allow(SuperGood::SolidusTaxjar::APIParams)
           .to receive(:order_params)
           .with(order)
           .and_return({some: "hash", with: "stuff", in: "it"})
@@ -23,7 +23,7 @@ RSpec.describe SuperGood::SolidusTaxJar do
 
     describe ".discount_calculator" do
       subject { described_class.discount_calculator }
-      it { is_expected.to eq SuperGood::SolidusTaxJar::DiscountCalculator }
+      it { is_expected.to eq SuperGood::SolidusTaxjar::DiscountCalculator }
     end
 
     describe ".test_mode" do

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SuperGood::SolidusTaxjar do
       let(:order) { Spree::Order.new }
 
       it "returns the API params converted to JSON" do
-        allow(SuperGood::SolidusTaxjar::APIParams)
+        allow(SuperGood::SolidusTaxjar::ApiParams)
           .to receive(:order_params)
           .with(order)
           .and_return({some: "hash", with: "stuff", in: "it"})

--- a/super_good-solidus_taxjar.gemspec
+++ b/super_good-solidus_taxjar.gemspec
@@ -4,7 +4,7 @@ require "super_good/solidus_taxjar/version"
 
 Gem::Specification.new do |spec|
   spec.name = "super_good-solidus_taxjar"
-  spec.version = SuperGood::SolidusTaxJar::VERSION
+  spec.version = SuperGood::SolidusTaxjar::VERSION
   spec.authors = ["Jared Norman"]
   spec.email = ["jared@super.gd"]
 


### PR DESCRIPTION
What is the goal of this PR?
---

Support loading this extension with the zeitwork loader

This is a breaking change due the renaming of the module

How do you manually test these changes? (if applicable)
---

1. Set up this gem in a rails project that uses zeitwork
    * [x] Ensure it loads properly and can be used to calculate taxes

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
