### PR TITLE
Update the engine name

### DIFF
--- a/lib/super_good/engine.rb
+++ b/lib/super_good/engine.rb
@@ -3,6 +3,6 @@
 module SuperGoodSolidusTaxjar
   class Engine < Rails::Engine
     isolate_namespace Spree
-    engine_name 'super_good-solidus_taxjar'
+    engine_name 'super_good_solidus_taxjar'
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

Once we add an install generator with migrations, having an engine name with a dash in it will cause the migration generation to fail, as migrations will be created with the engine name in it, and dashes are not allowed.
