### PR TITLE
Fix typo in address parameter helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- [#47](https://github.com/SuperGoodSoft/solidus_taxjar/pull/47) Fixed bug in `validate_address_params` for addresses without a state
+
 ## v0.18.0
 
 - [#21](https://github.com/SuperGoodSoft/solidus_taxjar/pull/21) Migrated project to `solidus_dev_support`

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -69,7 +69,7 @@ module SuperGood
         def validate_address_params(spree_address)
           {
             country: spree_address.country&.iso,
-            state: spree_address.state&.abbr || adddress.state_name,
+            state: spree_address.state&.abbr || spree_address.state_name,
             zip: spree_address.zipcode,
             city: spree_address.city,
             street: spree_address.address1

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -389,7 +389,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       end
 
       it "uses the state_name to build address params" do
-        pending("fix for state name fallback")
         expect(subject).to eq({
           country: "GB",
           state: "West Midlands",

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -362,5 +362,42 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
         street: "475 N Beverly Dr"
       })
     end
+
+    context "with an address without a state" do
+      let(:ship_address) do
+        Spree::Address.create!(
+          address1: "72 High St",
+          city: "Birmingham",
+          country: country_uk,
+          first_name: "Chuck",
+          last_name: "Schuldiner",
+          phone: "1-250-555-4444",
+          state_name: "West Midlands",
+          zipcode: "B4 7TA"
+        )
+      end
+
+      let(:country_uk) do
+        Spree::Country.create!(
+          iso3: "GBR",
+          iso: "GB",
+          iso_name: "UNITED KINGDOM",
+          name: "United Kingdom",
+          numcode: 826,
+          states_required: false
+        )
+      end
+
+      it "uses the state_name to build address params" do
+        pending("fix for state name fallback")
+        expect(subject).to eq({
+          country: "GB",
+          state: "West Midlands",
+          zip: "B4 7TA",
+          city: "Birmingham",
+          street: "72 High St"
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---
Fixes a typo in the helper method which transforms a `Spree::Address` into the payload parameters we send to TaxJar.


How do you manually test these changes? (if applicable)
---

1. Use an order with an address without a `state` association, but with a `state_name` instead.
    * [ ] The order address should be serialized correctly and the `state_name` field should be serialized and sent to Tax Jar.

Merge Checklist
---

- [ ] Run the manual tests
- [ ] ~Update the changelog~ (I am not sure if this needs to be done for this change?)