### PR TITLE
Add TaxJar `nexus_regions` API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 ## master
 
-## v0.18.1 
+- [#51](https://github.com/SuperGoodSoft/solidus_taxjar/pull/51) Add nexus regions method to API
+
+## v0.18.1
 
 [#52](https://github.com/supergoodsoft/solidus_taxjar/pull/52) fixes a critical bug in the API class that was released in `v0.18.0`. Please upgrade.
 
 - [#47](https://github.com/SuperGoodSoft/solidus_taxjar/pull/47) Fixed bug in `validate_address_params` for addresses without a state
 - [#52](https://github.com/supergoodsoft/solidus_taxjar/pull/52) Fixed critical bug in API class
 
-## ~~v0.18.0~~ 
+## ~~v0.18.0~~
 `v0.18.0` was removed due to a regression in the API class that was fixed in [#52](https://github.com/SuperGoodSoft/solidus_taxjar/pull/52) and `v0.18.1`
 
 - [#21](https://github.com/SuperGoodSoft/solidus_taxjar/pull/21) Migrated project to `solidus_dev_support`

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -55,6 +55,10 @@ module SuperGood
         taxjar_client.validate_address ApiParams.validate_address_params(spree_address)
       end
 
+      def nexus_regions
+        taxjar_client.nexus_regions
+      end
+
       private
 
       attr_reader :taxjar_client

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -202,4 +202,19 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
 
     it { is_expected.to eq({some_kind_of: "response"}) }
   end
+
+  describe "#nexus_regions" do
+    subject { api.nexus_regions }
+
+    let(:api) { described_class.new(taxjar_client: dummy_client) }
+    let(:dummy_client) { instance_double ::Taxjar::Client }
+
+    before do
+      allow(dummy_client)
+        .to receive(:nexus_regions)
+        .and_return({some_kind_of: "response"})
+    end
+
+    it { is_expected.to eq({some_kind_of: "response"}) }
+  end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

Add an API call needed by myself and @Noah-Silvera to implement #42, and to support #32

How do you manually test these changes? (if applicable)
---

1. Open a rails console.
2. Call the `nexus_regions` method manually and verify it behaves as you expect.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
