### PR TITLE
Fix critical bug in API class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## master
 
-- [#47](https://github.com/SuperGoodSoft/solidus_taxjar/pull/47) Fixed bug in `validate_address_params` for addresses without a state
+[#52](https://github.com/supergoodsoft/solidus_taxjar/pull/52) fixes a critical bug in the API class that was released in `v0.18.0`. Please upgrade.
 
-## v0.18.0
+- [#47](https://github.com/SuperGoodSoft/solidus_taxjar/pull/47) Fixed bug in `validate_address_params` for addresses without a state
+- [#52](https://github.com/supergoodsoft/solidus_taxjar/pull/52) Fixed critical bug in API class
+
+## ~~v0.18.0~~ 
+`v0.18.0` was removed due to a regression in the API class that was fixed in [#52](https://github.com/SuperGoodSoft/solidus_taxjar/pull/52) and `v0.18.1`
 
 - [#21](https://github.com/SuperGoodSoft/solidus_taxjar/pull/21) Migrated project to `solidus_dev_support`
 - [#22](https://github.com/SuperGoodSoft/solidus_taxjar/pull/22) Added support for TaxJar address validation API through `SuperGood::SolidusTaxJar::Addresses` class

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -2,13 +2,15 @@ module SuperGood
   module SolidusTaxjar
     class Api
       def self.default_taxjar_client
-        ::Taxjar::Client.new(
+        client = ::Taxjar::Client.new(
           api_key: ENV.fetch("TAXJAR_API_KEY"),
           api_url: ENV.fetch("TAXJAR_API_URL") { "https://api.taxjar.com" } # Sandbox URL: https://api.sandbox.taxjar.com
-        ).set_api_config('headers', {
+        )
+        client.set_api_config('headers', {
           'x-api-version' => '2020-08-07',
           'plugin' => 'supergoodsolidustaxjar'
         })
+        client
       end
 
       def initialize(taxjar_client: self.class.default_taxjar_client)

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
     end
   end
 
+  describe ".default_taxjar_client" do
+    subject { described_class.default_taxjar_client }
+
+    before do
+      ENV["TAXJAR_API_KEY"] = 'taxjar_api_token'
+    end
+
+    it "returns an instance of the TaxJar client" do
+      expect(subject).to be_an_instance_of(::Taxjar::Client)
+    end
+  end
+
+
   describe "#tax_for" do
     subject { api.tax_for order }
 

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe ".new" do
     subject { described_class.new }
 
-    let(:dummy_client) { instance_double ::Taxjar::Client }
-
     before do
       ENV["TAXJAR_API_KEY"] = 'taxjar_api_token'
     end


### PR DESCRIPTION
What is the goal of this PR?
---

In #34, we modified `.default_taxjar_client` to include the API version,
and then the name of the plugin, but we also introduced a critical bug.
`Taxjar::Client#set_api_config` returns a hash and not the TaxJar
client, so it is not safe to chain the method call. As such, we add a
spec to cover this case and patch the class method.

How do you manually test these changes? (if applicable)
---

1. Setup a sandbox store `bin/rails-sandbox server`
2. Setup the store to use this gem as the default tax calculator
3. Checkout from the store and verify you see taxes on the page

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
