### PR TITLE
Take adjustments into account when calculating shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - [#51](https://github.com/SuperGoodSoft/solidus_taxjar/pull/51) Add nexus regions method to API
+- [#58](https://github.com/SuperGoodSoft/solidus_taxjar/pull/58) Take shipping promotions into account in default calculator
 
 ## v0.18.1
 

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -44,7 +44,7 @@ module SuperGood
     }
     self.line_item_tax_label_maker = ->(taxjar_line_item, spree_line_item) { "Sales Tax" }
     self.logging_enabled = false
-    self.shipping_calculator = ->(order) { order.shipment_total }
+    self.shipping_calculator = ->(order) { order.shipments.sum(&:total_before_tax) }
     self.shipping_tax_label_maker = ->(shipment, shipping_tax) { "Sales Tax" }
     self.taxable_address_check = ->(address) { true }
     self.taxable_order_check = ->(order) { true }

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       line_items: [line_item],
       number: "R111222333",
       ship_address: ship_address,
-      shipment_total: BigDecimal("3.01"),
       store: store,
       total: order_total,
+      shipments: [shipment],
       user_id: 12345
     ).tap do |order|
       order.update! completed_at: DateTime.new(2018, 3, 6, 12, 10, 33)
@@ -118,6 +118,8 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       total: 333.33
     )
   end
+
+  let(:shipment) { Spree::Shipment.create!(cost: BigDecimal("3.01")) }
 
   describe "#order_params" do
     subject { described_class.order_params(order) }

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -73,5 +73,15 @@ RSpec.describe SuperGood::SolidusTaxjar do
       let(:spree_line_item) { Spree::LineItem.new }
       it { is_expected.to eq "Sales Tax" }
     end
+
+    describe ".shipping_calculator" do
+      subject { described_class.shipping_calculator.call(order) }
+
+      let(:order) { instance_double(Spree::Order, shipment_total: 10) }
+
+      it "returns the shipment total" do
+        expect(subject).to eq(10)
+      end
+    end
   end
 end

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -77,9 +77,14 @@ RSpec.describe SuperGood::SolidusTaxjar do
     describe ".shipping_calculator" do
       subject { described_class.shipping_calculator.call(order) }
 
-      let(:order) { instance_double(Spree::Order, shipment_total: 10) }
+      let(:order) { create :order }
+      let(:shipment) { create :shipment, order: order, cost: 20 }
 
-      it "returns the shipment total" do
+      before do
+        create :adjustment, order: order, adjustable: shipment, amount: -10, eligible: true, source: create(:shipping_rate, shipment: shipment)
+      end
+
+      it "returns the shipment total including promotions" do
         expect(subject).to eq(10)
       end
     end


### PR DESCRIPTION
What is the goal of this PR?
---

The current default shipping calculator did not consider promotions when calculating shipping.

How do you manually test these changes? (if applicable)
---

1. Create a shipment
2. Add a promotion to the shipment to reduce it's cost
3. Ensure the shipment cost on the checkout screen takes the promotion into account

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

Screenshots
---
