### PR TITLE
Use spree address2 if it is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#59](https://github.com/SuperGoodSoft/solidus_taxjar/pull/59) Add pry debugging tools
 - [#69](https://github.com/SuperGoodSoft/solidus_taxjar/pull/69) Lock ExecJS version
 - [#37](https://github.com/SuperGoodSoft/solidus_taxjar/pull/37) Added a basic Taxjar settings admin interface which displays placeholder text.
+- [#64](https://github.com/SuperGoodSoft/solidus_taxjar/pull/64) Provide Spree::Address.address2 to TaxJar address validation if it is present.
 
 ## v0.18.1
 

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -72,7 +72,7 @@ module SuperGood
             state: spree_address.state&.abbr || spree_address.state_name,
             zip: spree_address.zipcode,
             city: spree_address.city,
-            street: spree_address.address1
+            street: [spree_address.address1, spree_address.address2].compact.join(' ')
           }
         end
 

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -400,5 +400,35 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
         })
       end
     end
+
+    context "an address with address2" do
+      let(:ship_address) do
+        Spree::Address.create!(
+          address1: "1 World Trade CTR",
+          address2: "STE 45A",
+          city: "New York",
+          country: country_us,
+          first_name: "Chuck",
+          last_name: "Schuldiner",
+          phone: "1-250-555-4444",
+          state: Spree::State.create!(
+            abbr: "NY",
+            country: country_us,
+            name: "New York"
+          ),
+          zipcode: "10007"
+        )
+      end
+
+      it "concatenates address1 and address2 into the street parameter" do
+        expect(subject).to eq({
+          country: "US",
+          state: "NY",
+          zip: "10007",
+          city: "New York",
+          street: "1 World Trade CTR STE 45A"
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

The taxjar validation API has the option to take a freeform street input consisting of the full address. This means that if both address1 and address2 exist, we should concatenate them and pass them to the street parameter.

This can help with situations that involve a ZIP+4 code in the US for example. A user may enter their 5 digit zip code in the zip code field, but enter their ZIP+4 code in the address2 field.

How do you manually test these changes? (if applicable)
---

1. Manually call this API with a valid taxjar key and the situation described above with a ZIP+4 code. Ensure the address is validated correctly with the ZIP+4 code in the freeform input taken into account

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
