### PR TITLE
Lock ExecJS and solidus extensions orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,6 @@
 version: 2.1
 orbs:
-  # Always take the latest version of the orb, this allows us to
-  # run specs against Solidus supported versions only without the need
-  # to change this configuration every time a Solidus version is released
-  # or goes EOL.
-  solidusio_extensions: solidusio/extensions@volatile
+  solidusio_extensions: solidusio/extensions@0.2.24
 
 jobs:
   run-specs-with-postgres:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#51](https://github.com/SuperGoodSoft/solidus_taxjar/pull/51) Add nexus regions method to API
 - [#58](https://github.com/SuperGoodSoft/solidus_taxjar/pull/58) Take shipping promotions into account in default calculator
 - [#59](https://github.com/SuperGoodSoft/solidus_taxjar/pull/59) Add pry debugging tools
+- [#69](https://github.com/SuperGoodSoft/solidus_taxjar/pull/69) Lock ExecJS version
 
 ## v0.18.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ gem "rails", ENV.fetch("RAILS_VERSION") { ">0.a" }
 
 # Provides basic authentication functionality for testing parts of your engine
 gem "solidus_auth_devise"
+# ExecJS 2.8 has a bug in it which breaks js precompiling, which is required for our features
+# specs. Many other solidus extensions are also experiencing failing specs because of this.
+# For now, we should lock the version of ExecJS until a new release comes out that fixes this bug.
+gem "execjs", '~> 2.7.0'
 
 case ENV["DB"]
 when "mysql"


### PR DESCRIPTION
What is the goal of this PR?
---

ExecJS released a minor version update with a breaking change. We want to lock to the previous version (2.7) for now until a fix is released.

https://github.com/rails/execjs/issues/99

Merge Checklist
---

- [x] Specs pass
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
