### PR TITLE
Lock `execjs` to 2.7 in sandbox app

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -53,6 +53,7 @@ gem 'solidus', github: 'solidusio/solidus', branch: '$BRANCH'
 gem 'solidus_auth_devise', '>= 2.1.0'
 gem 'rails-i18n'
 gem 'solidus_i18n'
+gem 'execjs', '2.7.0'
 
 gem '$extension_name', path: '..'
 


### PR DESCRIPTION
ExecJS released a minor version update with a breaking change. We want
to lock to the previous version (2.7) for now until a fix is released.

What is the goal of this PR?
---

Fix the sandbox app

How do you manually test these changes? (if applicable)
---

- [ ] `bin/rails-sandbox s` and hit `localhost:3000`

Merge Checklist
---

- [ ] Run the manual tests