### PR TITLE
Unlock the ExecJS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#71](https://github.com/SuperGoodSoft/solidus_taxjar/pull/69) Unlock ExecJS version. This reverts the temporary fix introduced in #69
 - [#79](https://github.com/SuperGoodSoft/solidus_taxjar/pull/79) Relax Ruby required version to support Ruby 3.0+
 - [#51](https://github.com/SuperGoodSoft/solidus_taxjar/pull/51) Add nexus regions method to API
 - [#58](https://github.com/SuperGoodSoft/solidus_taxjar/pull/58) Take shipping promotions into account in default calculator

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,6 @@ gem "rails", ENV.fetch("RAILS_VERSION") { ">0.a" }
 
 # Provides basic authentication functionality for testing parts of your engine
 gem "solidus_auth_devise"
-# ExecJS 2.8 has a bug in it which breaks js precompiling, which is required for our features
-# specs. Many other solidus extensions are also experiencing failing specs because of this.
-# For now, we should lock the version of ExecJS until a new release comes out that fixes this bug.
-gem "execjs", '~> 2.7.0'
 
 case ENV["DB"]
 when "mysql"


### PR DESCRIPTION
What is the goal of this PR?
---

A new release of ExecJS (2.8.1) patched a bug which was preventing the app from booting, and autoprefixer, which indirectly requires ExecJS for this app, temporarily locked ExecJS to a working version until  they fix a bug, so we no longer have to lock ExecJS ourselves.

Merge Checklist
---

- [x] Specs pass
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
