### PR TITLE
 Relax Ruby required version to support Ruby 3.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#79](https://github.com/SuperGoodSoft/solidus_taxjar/pull/79) Relax Ruby required version to support Ruby 3.0+
 - [#51](https://github.com/SuperGoodSoft/solidus_taxjar/pull/51) Add nexus regions method to API
 - [#58](https://github.com/SuperGoodSoft/solidus_taxjar/pull/58) Take shipping promotions into account in default calculator
 - [#59](https://github.com/SuperGoodSoft/solidus_taxjar/pull/59) Add pry debugging tools

--- a/super_good-solidus_taxjar.gemspec
+++ b/super_good-solidus_taxjar.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/SuperGoodSoft/solidus_taxjar"
   spec.license = 'BSD-3-Clause'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = ">= 2.5.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
What is the goal of this PR?
---

This PR removes Ruby version upper limit in gemspec to make the gem work with Ruby 3.0.
0.17 version already worked correctly with Ruby 3, but https://github.com/SuperGoodSoft/solidus_taxjar/pull/21 introduced the new restriction.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
