### PR TITLE
Support order_recalculated event in Solidus < 2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#69](https://github.com/SuperGoodSoft/solidus_taxjar/pull/69) Lock ExecJS version
 - [#37](https://github.com/SuperGoodSoft/solidus_taxjar/pull/37) Added a basic Taxjar settings admin interface which displays placeholder text.
 - [#64](https://github.com/SuperGoodSoft/solidus_taxjar/pull/64) Provide Spree::Address.address2 to TaxJar address validation if it is present.
+- [#80](https://github.com/SuperGoodSoft/solidus_taxjar/pull/80) Support order_recalculated event in < 2.11
 
 ## v0.18.1
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The extension provides currently two high level `calculator` classes that wrap t
 * tax calculator
 * tax rate calculator
 
+The extension requires the `order_recalculated` event which is not supported on Solidus < 2.11, so this extension provides a [compatibility layer](app/decorators/super_good/solidus_taxjar/spree/order_updater/fire_recalculated_event.rb).
+
 ### TaxCalculator
 
 `SuperGood::SolidusTaxjar::TaxCalculator` allows calculating the full tax breakdown for a given `Spree::Order`. The breakdown includes separate line items taxes and shipment taxes.

--- a/app/decorators/super_good/solidus_taxjar/spree/order_updater/fire_recalculated_event.rb
+++ b/app/decorators/super_good/solidus_taxjar/spree/order_updater/fire_recalculated_event.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SuperGood
+  module SolidusTaxjar
+    module Spree
+      module OrderUpdater
+        module FireRecalculatedEvent
+          def persist_totals
+            ::Spree::Event.fire 'order_recalculated', order: order
+            super
+          end
+
+          ::Spree::OrderUpdater.prepend(self) if ::Spree.solidus_gem_version < Gem::Version.new('2.11.0')
+        end
+      end
+    end
+  end
+end

--- a/lib/super_good/engine.rb
+++ b/lib/super_good/engine.rb
@@ -4,5 +4,7 @@ module SuperGoodSolidusTaxjar
   class Engine < Rails::Engine
     isolate_namespace Spree
     engine_name 'super_good_solidus_taxjar'
+
+    include SolidusSupport::EngineExtensions
   end
 end

--- a/lib/super_good/solidus_taxjar/addresses.rb
+++ b/lib/super_good/solidus_taxjar/addresses.rb
@@ -20,7 +20,7 @@ module SuperGood
 
         return if taxjar_address.nil?
 
-        Spree::Address.immutable_merge(spree_address, {
+        ::Spree::Address.immutable_merge(spree_address, {
           country: us, # TaxJar only supports the US currently.
           state: state(taxjar_address.state),
           zipcode: taxjar_address.zip,
@@ -31,7 +31,7 @@ module SuperGood
 
       def possibilities(spree_address)
         taxjar_addresses(spree_address).map { |taxjar_address|
-          Spree::Address.immutable_merge(spree_address, {
+          ::Spree::Address.immutable_merge(spree_address, {
             country: us, # TaxJar only supports the US currently.
             state: state(taxjar_address.state),
             zipcode: taxjar_address.zip,
@@ -52,7 +52,7 @@ module SuperGood
       end
 
       def us
-        Spree::Country.find_by iso: "US"
+        ::Spree::Country.find_by iso: "US"
       end
 
       def state(abbr)

--- a/lib/super_good/solidus_taxjar/calculator_helper.rb
+++ b/lib/super_good/solidus_taxjar/calculator_helper.rb
@@ -4,7 +4,7 @@ module SuperGood
       extend ActiveSupport::Concern
 
       def incomplete_address?(address)
-        return true if address.is_a?(Spree::Tax::TaxLocation)
+        return true if address.is_a?(::Spree::Tax::TaxLocation)
 
         [
           address.address1,

--- a/lib/super_good/solidus_taxjar/tax_calculator.rb
+++ b/lib/super_good/solidus_taxjar/tax_calculator.rb
@@ -17,7 +17,7 @@ module SuperGood
         cache do
           next no_tax unless taxjar_breakdown
 
-          Spree::Tax::OrderTax.new(
+          ::Spree::Tax::OrderTax.new(
             order_id: order.id,
             line_item_taxes: line_item_taxes,
             shipment_taxes: shipment_taxes
@@ -41,7 +41,7 @@ module SuperGood
             # orders aren't going to have a huge number of line items.
             spree_line_item = order.line_items.find { |li| li.id == spree_line_item_id }
 
-            Spree::Tax::ItemTax.new(
+            ::Spree::Tax::ItemTax.new(
               item_id: spree_line_item_id,
               label: line_item_tax_label(taxjar_line_item, spree_line_item),
               tax_rate: tax_rate,
@@ -102,7 +102,7 @@ module SuperGood
       end
 
       def no_tax
-        Spree::Tax::OrderTax.new(
+        ::Spree::Tax::OrderTax.new(
           order_id: order.id,
           line_item_taxes: [],
           shipment_taxes: []
@@ -110,7 +110,7 @@ module SuperGood
       end
 
       def tax_rate
-        Spree::TaxRate.find_by(name: "Sales Tax")
+        ::Spree::TaxRate.find_by(name: "Sales Tax")
       end
 
       def cache_key

--- a/spec/models/spree/order_updater_spec.rb
+++ b/spec/models/spree/order_updater_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Spree::OrderUpdater do
+  describe '#update' do
+    it 'fires the order_recalculated event exactly once' do
+      stub_const('Spree::Event', class_spy(Spree::Event))
+      order = create(:order)
+
+      described_class.new(order).update
+
+      expect(Spree::Event).to have_received(:fire).with('order_recalculated', order: order).once
+    end
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

Support order_recalculated event in Solidus < 2.11

How do you manually test these changes? (if applicable)
---

1. Load the sandbox app
    * [x] Verify the decorator is loaded

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
