### PR TITLE
Add install generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#37](https://github.com/SuperGoodSoft/solidus_taxjar/pull/37) Added a basic Taxjar settings admin interface which displays placeholder text.
 - [#64](https://github.com/SuperGoodSoft/solidus_taxjar/pull/64) Provide Spree::Address.address2 to TaxJar address validation if it is present.
 - [#80](https://github.com/SuperGoodSoft/solidus_taxjar/pull/80) Support order_recalculated event in < 2.11
+- [#81](https://github.com/SuperGoodSoft/solidus_taxjar/pull/81) Add install generator
 
 ## v0.18.1
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,11 @@ This is not a fork of [spree_taxjar](https://github.com/vinsol-spree-contrib/spr
 
        $ bundle
 
-2. Next, configure Solidus to use this gem:
+2. Next, configure Solidus to use this gem by running the install generator:
 
-   ```ruby
-   # Put this in config/initializers/solidus.rb
-
-   Spree.config do |config|
-     config.tax_calculator_class = SuperGood::SolidusTaxjar::TaxCalculator
-   end
-   ```
+  ```sh
+  bundle exec rails generate super_good:solidus_taxjar:install
+  ```
 
 3. Also, configure your error handling:
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -75,6 +75,7 @@ unbundled bundle exec rails generate spree:install \
   $@
 
 unbundled bundle exec rails generate solidus:auth:install
+unbundled bundle exec rails generate super_good:solidus_taxjar:install
 
 echo
 echo "🚀 Sandbox app successfully created for $extension_name!"

--- a/lib/generators/super_good/solidus_taxjar/install_generator.rb
+++ b/lib/generators/super_good/solidus_taxjar/install_generator.rb
@@ -1,0 +1,18 @@
+module SuperGood
+  module SolidusTaxjar
+    module Generators
+      class InstallGenerator < Rails::Generators::Base
+        def create_initializer_file
+          solidus_initializer_path = "config/initializers/solidus.rb"
+
+          create_file(solidus_initializer_path) unless File.exists?(solidus_initializer_path)
+          append_to_file(solidus_initializer_path, <<~INIT)
+            Spree.config do |config|
+              config.tax_calculator_class = SuperGood::SolidusTaxjar::TaxCalculator
+            end
+          INIT
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---
Prior to this commit, users were required to manually configure this
extension after installing the gem. We add an install generator so users
can run a single command to handle this.

We include this command in the sandbox script so the sandbox is
ready to use this extension by default.



How do you manually test these changes? (if applicable)
---

- Create a fresh sandbox app
- Verify it uses this tax calculator by default and generates `sandbox/config/initializers/solidus.rb`


Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
- [ ] Run a sandbox app and verify taxes are being calculated
