### PR TITLE
Update refund api call to take into account line items

### DIFF
--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -57,6 +57,11 @@ module SuperGood
           {}
             .merge(order_address_params(reimbursement.order.tax_address))
             .merge(
+              refund_transaction_line_items_params(
+                reimbursement.return_items.map(&:inventory_unit).map(&:line_item).compact
+              )
+            )
+            .merge(
               transaction_id: reimbursement.number,
               transaction_reference_id: reimbursement.order.number,
               transaction_date: reimbursement.order.completed_at.to_formatted_s(:iso8601),
@@ -119,6 +124,21 @@ module SuperGood
                 unit_price: line_item.price,
                 discount: discount(line_item),
                 sales_tax: line_item_sales_tax(line_item)
+              }
+            end
+          }
+        end
+
+        def refund_transaction_line_items_params(line_items)
+          {
+            line_items: valid_line_items(line_items).map do |line_item|
+              {
+                id: line_item.id,
+                quantity: line_item.quantity,
+                product_identifier: line_item.sku,
+                product_tax_code: line_item.tax_category&.tax_code,
+                unit_price: -1 * line_item.price,
+                sales_tax: -1 * line_item_sales_tax(line_item)
               }
             end
           }

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -60,9 +60,9 @@ module SuperGood
               transaction_id: reimbursement.number,
               transaction_reference_id: reimbursement.order.number,
               transaction_date: reimbursement.order.completed_at.to_formatted_s(:iso8601),
-              amount: reimbursement.total - additional_taxes,
+              amount: -1 * (reimbursement.total - additional_taxes),
               shipping: 0,
-              sales_tax: additional_taxes
+              sales_tax: -1 * additional_taxes
             )
         end
 

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -107,18 +107,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
     )
   end
 
-  let(:reimbursement) do
-    Spree::Reimbursement.new(
-      number: "RI123123123",
-      order: order,
-      return_items: [
-        Spree::ReturnItem.new(additional_tax_total: 0.33),
-        Spree::ReturnItem.new(additional_tax_total: 33.0)
-      ],
-      total: 333.33
-    )
-  end
-
   let(:shipment) { Spree::Shipment.create!(cost: BigDecimal("3.01")) }
 
   describe "#order_params" do
@@ -334,6 +322,18 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
   describe "#refund_params" do
     subject { described_class.refund_params(reimbursement) }
+
+    let(:reimbursement) do
+      Spree::Reimbursement.new(
+        number: "RI123123123",
+        order: order,
+        return_items: [
+          Spree::ReturnItem.new(additional_tax_total: 0.33),
+          Spree::ReturnItem.new(additional_tax_total: 33.0)
+        ],
+        total: 333.33
+      )
+    end
 
     it "returns params for creating/updating a refund" do
       expect(subject).to eq({

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -328,17 +328,16 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
         number: "RI123123123",
         order: order,
         return_items: [
-          Spree::ReturnItem.new(additional_tax_total: 0.33),
-          Spree::ReturnItem.new(additional_tax_total: 33.0)
+          Spree::ReturnItem.new(additional_tax_total: 12, amount: 36),
         ],
-        total: 333.33
+        total: 36
       )
     end
 
     it "returns params for creating/updating a refund" do
       expect(subject).to eq({
-        amount: BigDecimal("300.00"),
-        sales_tax: BigDecimal("33.33"),
+        amount: BigDecimal("-24"),
+        sales_tax: BigDecimal("-12"),
         shipping: 0,
         to_city: "Los Angeles",
         to_country: "US",


### PR DESCRIPTION
What is the goal of this PR?
---

When an order transaction is created, the line items, their unit amounts, quantities, and sales tax is passed to the taxjar API.

For consistency and better reporting, we should pass the line items relevant to a refund when calling the taxjar refund endpoint.

How do you manually test these changes? (if applicable)
---

1. Do a thing
    * [ ] Assert a result

Merge Checklist
---

- [ ] Merge #86 
- [ ] Run the manual tests
- [ ] Update the changelog
- [ ] Run a sandbox app and verify taxes are being calculated

Screenshots
---
