### PR TITLE
Fix invalid refund endpoint call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - [#88](https://github.com/SuperGoodSoft/solidus_taxjar/pull/88) Fire `shipment_shipped` event when any shipment on an order ships.
+- [#86](https://github.com/SuperGoodSoft/solidus_taxjar/pull/86)  Fix invalid refund endpoint call.
 
 ## v0.18.2
 

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -60,9 +60,9 @@ module SuperGood
               transaction_id: reimbursement.number,
               transaction_reference_id: reimbursement.order.number,
               transaction_date: reimbursement.order.completed_at.to_formatted_s(:iso8601),
-              amount: reimbursement.total - additional_taxes,
+              amount: -1 * (reimbursement.total - additional_taxes),
               shipping: 0,
-              sales_tax: additional_taxes
+              sales_tax: -1 * additional_taxes
             )
         end
 

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -107,18 +107,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
     )
   end
 
-  let(:reimbursement) do
-    Spree::Reimbursement.new(
-      number: "RI123123123",
-      order: order,
-      return_items: [
-        Spree::ReturnItem.new(additional_tax_total: 0.33),
-        Spree::ReturnItem.new(additional_tax_total: 33.0)
-      ],
-      total: 333.33
-    )
-  end
-
   let(:shipment) { Spree::Shipment.create!(cost: BigDecimal("3.01")) }
 
   describe "#order_params" do
@@ -334,6 +322,18 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
   describe "#refund_params" do
     subject { described_class.refund_params(reimbursement) }
+
+    let(:reimbursement) do
+      Spree::Reimbursement.new(
+        number: "RI123123123",
+        order: order,
+        return_items: [
+          Spree::ReturnItem.new(additional_tax_total: 0.33),
+          Spree::ReturnItem.new(additional_tax_total: 33.0)
+        ],
+        total: 333.33
+      )
+    end
 
     it "returns params for creating/updating a refund" do
       expect(subject).to eq({

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -328,17 +328,16 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
         number: "RI123123123",
         order: order,
         return_items: [
-          Spree::ReturnItem.new(additional_tax_total: 0.33),
-          Spree::ReturnItem.new(additional_tax_total: 33.0)
+          Spree::ReturnItem.new(additional_tax_total: 12, amount: 36),
         ],
-        total: 333.33
+        total: 36
       )
     end
 
     it "returns params for creating/updating a refund" do
       expect(subject).to eq({
-        amount: BigDecimal("300.00"),
-        sales_tax: BigDecimal("33.33"),
+        amount: BigDecimal("-24"),
+        sales_tax: BigDecimal("-12"),
         shipping: 0,
         to_city: "Los Angeles",
         to_country: "US",


### PR DESCRIPTION
What is the goal of this PR?
---

The refund endpoint is meant to be used to post a transaction that represents the delta of changes to the order. This means that the amounts for the order total and sales tax passed should be negative.

An example can be found in the taxjar API

https://developers.taxjar.com/api/reference/?shell#post-create-a-refund-transaction

How do you manually test these changes? (if applicable)
---

1. Manually trigger the `create_refund_for` endpoint on the extension 
    * [x] Ensure a refund with the appropriate negative values is created on your taxjar account

Merge Checklist
---

- [x] Run the manual tests
- [ ] Update the changelog
- [ ] Run a sandbox app and verify taxes are being calculated
