### PR TITLE
#77 Add shipment shipped event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## master
+
+- [#88](https://github.com/SuperGoodSoft/solidus_taxjar/pull/88) Fire `shipment_shipped` event when any shipment on an order ships.
+
 ## v0.18.2
 
 - [#71](https://github.com/SuperGoodSoft/solidus_taxjar/pull/69) Unlock ExecJS version. This reverts the temporary fix introduced in #69

--- a/app/decorators/super_good/solidus_taxjar/spree/shipment/fire_shipment_shipped_event.rb
+++ b/app/decorators/super_good/solidus_taxjar/spree/shipment/fire_shipment_shipped_event.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SuperGood
+  module SolidusTaxjar
+    module Spree
+      module Shipment
+        module FireShipmentShippedEvent
+          def after_ship
+            ::Spree::Event.fire 'shipment_shipped', shipment: self
+            super
+          end
+
+          ::Spree::Shipment.prepend(self)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Spree::Shipment do
+  describe '#update' do
+    subject { shipment.ship }
+
+    let(:shipment) { create(:shipment, state: 'ready', order: order) }
+    let(:order) { create :order_with_line_items }
+
+    it 'fires the shipment_shipped event exactly once' do
+      stub_const('Spree::Event', class_spy(Spree::Event))
+
+      expect(Spree::Event).to receive(:fire).with('shipment_shipped', shipment: shipment).once
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

An an event for when any shipment ships. Orders need to be pushed to TaxJar whenever any part of the order is shipped, so we hook into solidus to add a new event to support this. 

Merge Checklist
---

- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

