### PR TITLE
Only require state for Canada and US addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#88](https://github.com/SuperGoodSoft/solidus_taxjar/pull/88) Fire `shipment_shipped` event when any shipment on an order ships.
 - [#81](https://github.com/SuperGoodSoft/solidus_taxjar/pull/81) Add install generator
+- [#95](https://github.com/SuperGoodSoft/solidus_taxjar/pull/95) Only require "state" for Canadian and US addresses
 
 ## v0.18.2
 

--- a/spec/super_good/solidus_taxjar/calculator_helper_spec.rb
+++ b/spec/super_good/solidus_taxjar/calculator_helper_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::CalculatorHelper do
+  class TestProxy
+    extend SuperGood::SolidusTaxjar::CalculatorHelper
+  end
+
+  describe "#incomplete_address?" do
+    subject { TestProxy.incomplete_address?(address) }
+
+    context "with a missing city" do
+      let(:address) { build :address, city: nil }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a missing address1" do
+      let(:address) { build :address, address1: nil }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a missing zipcode" do
+      let(:address) { build :address, zipcode: nil }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a missing state in CA" do
+      let(:address) { build :address, country_iso_code: "CA", state: nil }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a missing state in US" do
+      let(:address) { build :address, country_iso_code: "US", state: nil }
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a missing firstname" do
+      let(:address) { build :address, firstname: nil }
+      it { is_expected.to eq(false) }
+    end
+
+    context "with a missing state in DE" do
+      let(:address) { build :address, country_iso_code: "DE", state: nil }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "#state_required?" do
+    subject { TestProxy.state_required?(country) }
+
+    context "when the address' country is Canada" do
+      let(:country) { Spree::Country.new(iso: "CA") }
+      it { is_expected.to eq(true) }
+    end
+
+    context "when the address' country is the USA" do
+      let(:country) { Spree::Country.new(iso: "US") }
+      it { is_expected.to eq(true) }
+    end
+
+    context "when the address' country is neither Canada nor the USA" do
+      let(:country) { Spree::Country.new(iso: "FR") }
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

According to the TaxJar API, the `to_state` field is only required for
CA or US addresses. Right now, we consider an address incomplete if it
does not have a state, which breaks calculation of EU taxes as it is
commonplace to not have a "state"-equivalent.

We should change the incomplete check to only require the state if
TaxJar requires it for that country. This will allow calculation of tax
for EU addresses.

How do you manually test these changes? (if applicable)
---

Use an EU address with no "state", ensure taxes are still calculated.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
