### PR TITLE
TaxJar Reporting | Transaction ID generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#88](https://github.com/SuperGoodSoft/solidus_taxjar/pull/88) Fire `shipment_shipped` event when any shipment on an order ships.
 - [#81](https://github.com/SuperGoodSoft/solidus_taxjar/pull/81) Add install generator
 - [#95](https://github.com/SuperGoodSoft/solidus_taxjar/pull/95) Only require "state" for Canadian and US addresses
+- [#98](https://github.com/SuperGoodSoft/solidus_taxjar/pull/98) Add generator for TaxJar transaction IDs
 
 ## v0.18.2
 

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -3,6 +3,7 @@ require "solidus_support"
 require "taxjar"
 
 require "super_good/solidus_taxjar/version"
+require "super_good/solidus_taxjar/transaction_id_generator"
 require "super_good/solidus_taxjar/api_params"
 require "super_good/solidus_taxjar/api"
 require "super_good/solidus_taxjar/calculator_helper"

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -36,7 +36,10 @@ module SuperGood
       end
 
       def create_transaction_for(order)
-        taxjar_client.create_order ApiParams.transaction_params(order)
+        transaction_id = TransactionIdGenerator.next_transaction_id(order: order)
+        taxjar_client.create_order(
+          ApiParams.transaction_params(order, transaction_id)
+        )
       end
 
       def update_transaction_for(order)

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -37,13 +37,13 @@ module SuperGood
           }.merge(order_address_params(address))
         end
 
-        def transaction_params(order)
+        def transaction_params(order, transaction_id = order.number)
           {}
             .merge(customer_params(order))
             .merge(order_address_params(order.tax_address))
             .merge(transaction_line_items_params(order.line_items))
             .merge(
-              transaction_id: order.number,
+              transaction_id: transaction_id,
               transaction_date: order.completed_at.to_formatted_s(:iso8601),
               amount: [order.total - order.additional_tax_total, 0].max,
               shipping: shipping(order),

--- a/lib/super_good/solidus_taxjar/transaction_id_generator.rb
+++ b/lib/super_good/solidus_taxjar/transaction_id_generator.rb
@@ -1,0 +1,45 @@
+module SuperGood
+  module SolidusTaxjar
+    # Responsible for generating `transaction_id` references for transactions
+    # we create on TaxJar for Solidus orders. This class handles creating
+    # associated ID's for transactions which need to be cancelled and recreated
+    # when the order is updated in Solidus after it has been sent to the TaxJar
+    # reporting API.
+    class TransactionIdGenerator
+      class << self
+        # Generates the next sequential `transaction_id` given an order and
+        # optionally the current transaction ID on TaxJar. This handles the
+        # case where a transaction already has been created on TaxJar and later
+        # needs to be cancelled and we need to create an updated transaction
+        # with an associated identifier.
+        #
+        # @param order [Spree::Order] the order for which we want to generate a
+        #   transaction ID.
+        # @param current_transaction_id [String] the current transaction ID for
+        #   the order if it exists on TaxJar.
+        # @return [String] the next sequential `transaction_id`
+        def next_transaction_id(order:, current_transaction_id: nil)
+          if current_transaction_id.nil?
+            "#{order.number}"
+          elsif order.number == current_transaction_id
+            "#{current_transaction_id}-1"
+          else
+            parts = current_transaction_id.rpartition("-")
+            parts.last.next!
+            parts.join
+          end
+        end
+
+        # Generates a `transaction_id` for a refund transaction based on the
+        # ID of the transaction we're refunding.
+        #
+        # @param transaction_id [String] the ID of the transaction we are
+        #   refunding.
+        # @return [String] the expected refund transaction ID.
+        def refund_transaction_id(transaction_id)
+          "#{transaction_id}-REFUND"
+        end
+      end
+    end
+  end
+end

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -330,6 +330,18 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
         })
       end
     end
+
+    context "with an optional transaction_id specified" do
+      subject {
+        described_class.transaction_params(order, custom_transaction_id)
+      }
+
+      let(:custom_transaction_id) { "R0123456789" }
+
+      it "uses the specified transaction_id" do
+        expect(subject).to include(transaction_id: "R0123456789")
+      end
+    end
   end
 
   describe "#refund_params" do

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
   let(:shipment) { Spree::Shipment.create!(cost: BigDecimal("3.01")) }
 
-  describe "#order_params" do
+  describe ".order_params" do
     subject { described_class.order_params(order) }
 
     it "returns params for fetching the tax for the order" do
@@ -216,7 +216,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
     end
   end
 
-  describe "#address_params" do
+  describe ".address_params" do
     subject { described_class.address_params(ship_address) }
 
     it "returns params for fetching the tax info for that address" do
@@ -232,7 +232,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
     end
   end
 
-  describe "#tax_rate_address_params" do
+  describe ".tax_rate_address_params" do
     subject { described_class.tax_rate_address_params(ship_address) }
 
     it "returns params for fetching the tax rate for that address" do
@@ -250,7 +250,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
     end
   end
 
-  describe "#transaction_params" do
+  describe ".transaction_params" do
     subject { described_class.transaction_params(order) }
 
     it "returns params for creating/updating an order transaction" do

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
 
     let(:api) { described_class.new(taxjar_client: dummy_client) }
     let(:dummy_client) { instance_double ::Taxjar::Client }
-    let(:order) { Spree::Order.new }
+    let(:order) { build_stubbed :order, number: "R123" }
 
     before do
       allow(SuperGood::SolidusTaxjar::ApiParams)
         .to receive(:transaction_params)
-        .with(order)
+        .with(order, "R123")
         .and_return({transaction: "params"})
 
       allow(dummy_client)

--- a/spec/super_good/solidus_taxjar/transaction_id_generator_spec.rb
+++ b/spec/super_good/solidus_taxjar/transaction_id_generator_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::TransactionIdGenerator do
+  describe ".next_transaction_id" do
+    subject {
+      described_class.next_transaction_id(
+        order: order,
+        current_transaction_id: current_transaction_id
+      )
+    }
+
+    let(:order) { build :order, number: order_number }
+    let(:order_number) { "R1234567890" }
+
+    context "without a `current_transaction_id`" do
+      subject { described_class.next_transaction_id(order: order) }
+
+      it "uses the order.number as the transaction_id" do
+        expect(subject).to eq("R1234567890")
+      end
+
+      context "and there are dashes in the order number" do
+        let(:order_number) { "R123-456-7890" }
+
+        it "uses the order.number as the transaction_id" do
+          expect(subject).to eq("R123-456-7890")
+        end
+      end
+    end
+
+    context "with a `current_transaction_id`" do
+      context "when the current transaction ID does not have a suffix" do
+        let(:order_number) { "R1234567890" }
+        let(:current_transaction_id) { "R1234567890" }
+
+        it "generates the next sequential transaction_id" do
+          expect(subject).to eq("R1234567890-1")
+        end
+      end
+
+      context "when the current transaction ID has a suffix" do
+        let(:order_number) { "R1234567890" }
+        let(:current_transaction_id) { "R1234567890-2" }
+
+        it "generates the next sequential transaction_id" do
+          expect(subject).to eq("R1234567890-3")
+        end
+      end
+
+      context "when the current transaction ID contains more than one '-'" do
+        let(:order_number) { "R123-456-789-0" }
+        let(:current_transaction_id) { "R123-456-789-0-2" }
+
+        it "generates the next sequential transaction_id" do
+          expect(subject).to eq("R123-456-789-0-3")
+        end
+      end
+
+      context "when the current transaction ID suffix rolls over" do
+        let(:order_number) { "R1234567890" }
+        let(:current_transaction_id) { "R1234567890-99" }
+
+        it "generates the next sequential transaction_id" do
+          expect(subject).to eq("R1234567890-100")
+        end
+      end
+    end
+  end
+
+  describe ".refund_transaction_id" do
+    subject { described_class.refund_transaction_id(transaction_id) }
+
+    let(:transaction_id) { "R1234567890" }
+
+    it { is_expected.to eq("R1234567890-REFUND") }
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---
Finishes #94 

Introduce a utility class for generating `transaction_id`s for transactions
created using the TaxJar reporting API.

This is a step towards implementing a way to update transactions on TaxJar after
they have been updated in Solidus. The recommended way to reflect changes is to
cancel the original transaction and create a new one while referencing the old
one. However TaxJar does not have a way to associate two transactions in any way
so we will be using a suffix appended to the original order number and increment
that every time we cancel and re-create a transaction because the Solidus order
changed. This utility will aid in genrating a new `transaction_id` based on the
current one in TaxJar.

How do you manually test these changes? (if applicable)
---

1. Create a transaction on TaxJar using the API and confirm the `transaction_id`
  is the same as the `order.number`.
1. For now the method to generate a new `transaction_id` from a previous one is
  not used anywhere so testing that manually requires you to call the class on
  the console.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
