### PR TITLE
Add description to transaction line item params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#103](https://github.com/SuperGoodSoft/solidus_taxjar/pull/103) Add `reporting_enabled` configuration option
 - [#97](https://github.com/SuperGoodSoft/solidus_taxjar/pull/97) Add public API method to request the latest transaction associated with a solidus order.
 - [#100](https://github.com/SuperGoodSoft/solidus_taxjar/pull/100) Add public API method to post a taxjar refund transaction for a solidus order.
+- [#102](https://github.com/SuperGoodSoft/solidus_taxjar/pull/102) Add description to transaction line item params
 
 ## v0.18.2
 

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -137,6 +137,7 @@ module SuperGood
                 id: line_item.id,
                 quantity: line_item.quantity,
                 product_identifier: line_item.sku,
+                description: line_item.variant.descriptive_name,
                 product_tax_code: line_item.tax_category&.tax_code,
                 unit_price: line_item.price,
                 discount: discount(line_item),

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -74,7 +74,23 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
     Spree::Variant.create!(
       price: 10,
       product: product,
-      sku: "G00D-PR0DUCT"
+      sku: "G00D-PR0DUCT",
+      option_values: [option_value]
+    )
+  end
+
+  let(:option_value) do
+    Spree::OptionValue.create!(
+      name: "Red",
+      presentation: "red",
+      option_type: option_type
+    )
+  end
+
+  let(:option_type) do
+    Spree::OptionType.create!(
+      name: "Color",
+      presentation: "color"
     )
   end
 
@@ -261,6 +277,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
           discount: 2,
           id: line_item.id,
           product_identifier: "G00D-PR0DUCT",
+          description: "Product Name - color: red",
           product_tax_code: "A_GEN_TAX",
           quantity: 3,
           sales_tax: 4,
@@ -294,6 +311,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
           discount: 2,
           id: line_item.id,
           product_identifier: "G00D-PR0DUCT",
+          description: "Product Name - color: red",
           product_tax_code: "A_GEN_TAX",
           quantity: 3,
           sales_tax: 0,


### PR DESCRIPTION
It helps with TaxJars reporting tools to have a human readable
name for the object. TaxJar uses the "description" field for this
purpose.

Here's a screenshot of the different this makes. In the transaction details screen, the top item was created with the "description" field, and the bottom one was not.
<img width="688" alt="Screen Shot 2021-08-27 at 5 25 00 PM" src="https://user-images.githubusercontent.com/5720486/131190172-42d98ff3-a8b5-41dd-a51a-5d441bc2d933.png">

Manual Tests
---

* [x] Manually post a transaction using the `SuperGood::SolidusTaxjar::Api.create_transaction_for(order)` method in the console and ensure the description is shown on taxjar.

Merge Checklist
---

* [x] Run the manual tests
* [x] Update the changelog 
* [x] Run a sandbox solidus store with taxjar and ensure taxes are still being calculated