### PR TITLE
Add `reporting_enabled` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#81](https://github.com/SuperGoodSoft/solidus_taxjar/pull/81) Add install generator
 - [#95](https://github.com/SuperGoodSoft/solidus_taxjar/pull/95) Only require "state" for Canadian and US addresses
 - [#98](https://github.com/SuperGoodSoft/solidus_taxjar/pull/98) Add generator for TaxJar transaction IDs
+- [#103](https://github.com/SuperGoodSoft/solidus_taxjar/pull/103) Add `reporting_enabled` configuration option
 
 ## v0.18.2
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ introduced in Solidus v2.4. This maps better to how the TaxJar API itself works.
     }
     ```
 
+    For more information about configuring the extension, see
+    [Configuration](#configuration).
+
 1. Finally, make sure that the `TAXJAR_API_KEY` environment variable is set to
   your TaxJar API key and make sure that you have a `Spree::TaxRate` with the name
   "Sales Tax". This will be used as the source for the tax adjustments that
@@ -88,6 +91,24 @@ for a given `Spree::Address`. It relies on the same low-level Ruby TaxJar API
 endpoint of the tax calculator in order to provide the most coherent and
 reliable results. TaxJar support recommends using this endpoint for live
 calculations.
+
+## Configuration
+
+See [`lib/super_good/solidus_taxjar.rb`](lib/super_good/solidus_taxjar.rb) for a
+list of configuration options and their default values. You can override the
+default values in one of your Rails application's initializers:
+
+```ruby
+# config/initializers/taxjar.rb
+
+SuperGood::SolidusTaxjar.tap do |config|
+  config.cache_duration = 2.hours
+  config.line_item_tax_label_maker = ->(taxjar_line_item, spree_line_item) {
+    "My Tax Label"
+  }
+  config.test_mode = true
+end
+```
 
 ## Development
 

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -22,6 +22,7 @@ module SuperGood
       attr_accessor :exception_handler
       attr_accessor :line_item_tax_label_maker
       attr_accessor :logging_enabled
+      attr_accessor :reporting_enabled
       attr_accessor :shipping_calculator
       attr_accessor :shipping_tax_label_maker
       attr_accessor :taxable_address_check
@@ -45,6 +46,12 @@ module SuperGood
     }
     self.line_item_tax_label_maker = ->(taxjar_line_item, spree_line_item) { "Sales Tax" }
     self.logging_enabled = false
+
+    # The reporting feature is still in development. We recommend *not*
+    # enabling this feature until this comment has been removed from the source
+    # code.
+    self.reporting_enabled = false
+
     self.shipping_calculator = ->(order) { order.shipments.sum(&:total_before_tax) }
     self.shipping_tax_label_maker = ->(shipment, shipping_tax) { "Sales Tax" }
     self.taxable_address_check = ->(address) { true }

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe SuperGood::SolidusTaxjar do
       it { is_expected.to eq false }
     end
 
+    describe ".reporting_enabled" do
+      subject { described_class.reporting_enabled }
+
+      it "it defaults to false" do
+        expect(subject).to eq false
+      end
+    end
+
     describe ".exception_handler" do
       subject { described_class.exception_handler.call(exception) }
 


### PR DESCRIPTION
Closes #99.

What is the goal of this PR?
---

We want to allow end users to be able to turn the TaxJar reporting functionality of this extension on or off.

While the feature is in development, we want reporting to be disabled by default.


How do you manually test these changes? (if applicable)
---

Not applicable.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

Screenshots
---

Not applicable.