### PR TITLE
Point rails engine binstub at correct entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#97](https://github.com/SuperGoodSoft/solidus_taxjar/pull/97) Add public API method to request the latest transaction associated with a solidus order.
 - [#100](https://github.com/SuperGoodSoft/solidus_taxjar/pull/100) Add public API method to post a taxjar refund transaction for a solidus order.
 - [#102](https://github.com/SuperGoodSoft/solidus_taxjar/pull/102) Add description to transaction line item params
+- [#107](https://github.com/SuperGoodSoft/solidus_taxjar/pull/107) Fix rails-engine binstub to point to correct engine entry point
 
 ## v0.18.2
 

--- a/bin/rails-engine
+++ b/bin/rails-engine
@@ -3,7 +3,7 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path("..", __dir__)
-ENGINE_PATH = File.expand_path("../lib/solidus_taxjar/engine", __dir__)
+ENGINE_PATH = File.expand_path("../lib/super_good-solidus_taxjar", __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)


### PR DESCRIPTION
What is the goal of this PR?
---

The rails-engine binstub was pointing to the wrong entry point for the extension engine, so it couldn't be used to run various commands, such as generating migrations.

How do you manually test these changes? (if applicable)
---

* [x] Try generating a migration with the rails engine binstub 

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
