### PR TITLE
Add Taxjar transaction Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#100](https://github.com/SuperGoodSoft/solidus_taxjar/pull/100) Add public API method to post a taxjar refund transaction for a solidus order.
 - [#102](https://github.com/SuperGoodSoft/solidus_taxjar/pull/102) Add description to transaction line item params
 - [#107](https://github.com/SuperGoodSoft/solidus_taxjar/pull/107) Fix rails-engine binstub to point to correct engine entry point
+- [#108](https://github.com/SuperGoodSoft/solidus_taxjar/pull/108) Add new model associated with a `Spree::Order` to represent taxjar order creation transactions
 
 ## v0.18.2
 

--- a/app/decorators/super_good/solidus_taxjar/spree/order_decorator.rb
+++ b/app/decorators/super_good/solidus_taxjar/spree/order_decorator.rb
@@ -1,0 +1,16 @@
+module SuperGood
+  module SolidusTaxjar
+    module Spree
+      module OrderDecorator
+        def self.prepended(base)
+          base.has_many :taxjar_order_transactions,
+            class_name: "SuperGood::SolidusTaxjar::OrderTransaction",
+            dependent: :destroy,
+            inverse_of: :order
+        end
+
+        ::Spree::Order.prepend self
+      end
+    end
+  end
+end

--- a/app/models/super_good/solidus_taxjar/order_transaction.rb
+++ b/app/models/super_good/solidus_taxjar/order_transaction.rb
@@ -1,0 +1,9 @@
+module SuperGood
+  module SolidusTaxjar
+    class OrderTransaction < ActiveRecord::Base
+      belongs_to :order, class_name: "Spree::Order"
+
+      validates_presence_of :transaction_id
+    end
+  end
+end

--- a/db/migrate/20210908205201_create_taxjar_order_transactions.rb
+++ b/db/migrate/20210908205201_create_taxjar_order_transactions.rb
@@ -1,0 +1,16 @@
+class CreateTaxjarOrderTransactions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :solidus_taxjar_order_transactions do |t|
+      t.references :order, null: false
+      t.string :transaction_id, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :solidus_taxjar_order_transactions,
+      :spree_orders,
+      column: :order_id
+
+    add_index :solidus_taxjar_order_transactions, :transaction_id, unique: true
+  end
+end

--- a/lib/generators/super_good/solidus_taxjar/install_generator.rb
+++ b/lib/generators/super_good/solidus_taxjar/install_generator.rb
@@ -2,6 +2,8 @@ module SuperGood
   module SolidusTaxjar
     module Generators
       class InstallGenerator < Rails::Generators::Base
+        class_option :auto_run_migrations, type: :boolean, default: false
+
         def create_initializer_file
           solidus_initializer_path = "config/initializers/solidus.rb"
 
@@ -11,6 +13,19 @@ module SuperGood
               config.tax_calculator_class = SuperGood::SolidusTaxjar::TaxCalculator
             end
           INIT
+        end
+
+        def add_migrations
+          run 'bin/rails railties:install:migrations FROM=solidus_taxjar'
+        end
+
+        def run_migrations
+          run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
+          if run_migrations
+            run 'bin/rails db:migrate'
+          else
+            puts 'Skipping bin/rails db:migrate, don\'t forget to run it!'
+          end
         end
       end
     end

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -32,6 +32,10 @@ module SuperGood
       def api
         ::SuperGood::SolidusTaxjar::Api.new
       end
+
+      def table_name_prefix
+        "solidus_taxjar_"
+      end
     end
 
     self.cache_duration = 3.hours

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe SuperGood::SolidusTaxjar do
     expect(SuperGood::SolidusTaxjar::VERSION).not_to be nil
   end
 
+  describe ".table_name_prefix" do
+    subject { described_class.table_name_prefix }
+
+    it { is_expected.to eq("solidus_taxjar_") }
+  end
+
   describe "configuration" do
     describe ".cache_key" do
       subject { described_class.cache_key.call(order) }


### PR DESCRIPTION
What is the goal of this PR?
---

Orders can be associated with multiple taxjar transactions, so we should add a new model to keep track of this relationship. 

How do you manually test these changes? (if applicable)
---

1. Create a new `SuperGood::SolidusTaxjar::OrderTransaction` model
   * [x] Ensure it validates the presence of an order and `transaction_id`
   * [x] Ensure calling `taxjar_order_transactions` on the `Spree::Order` returns an association with the new transaction

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

This ticket is the first step to completing #101.