### PR TITLE
Save `OrderTransaction` after API call to TaxJar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#114](https://github.com/SuperGoodSoft/solidus_taxjar/pull/114) Add new model associated with a `SuperGood::SolidusTaxjar::OrderTransaction` to represent taxjar refund creation transactions
 - [#116](https://github.com/SuperGoodSoft/solidus_taxjar/pull/116) Update the `OrderTransaction` model to record the transaction date.
 - [#120](https://github.com/SuperGoodSoft/solidus_taxjar/pull/120) Change default `SOLIDUS_BRANCH` and `RAILS_VERSION`
+- [#109](https://github.com/SuperGoodSoft/solidus_taxjar/pull/109) Save `OrderTransaction` after API call to TaxJar
 
 ## v0.18.2
 

--- a/app/models/super_good/solidus_taxjar/order_transaction.rb
+++ b/app/models/super_good/solidus_taxjar/order_transaction.rb
@@ -5,6 +5,10 @@ module SuperGood
 
       validates_presence_of :transaction_id
       validates_presence_of :transaction_date
+
+      def self.latest_for(order)
+        where(order: order).order(transaction_date: :desc).limit(1).first
+      end
     end
   end
 end

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -37,9 +37,14 @@ module SuperGood
 
       def create_transaction_for(order)
         transaction_id = TransactionIdGenerator.next_transaction_id(order: order)
-        taxjar_client.create_order(
+        response = taxjar_client.create_order(
           ApiParams.transaction_params(order, transaction_id)
         )
+        order.taxjar_order_transactions.create!(
+          transaction_id: response.transaction_id,
+          transaction_date: response.transaction_date
+        )
+        response
       end
 
       def update_transaction_for(order)

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -56,7 +56,14 @@ module SuperGood
       end
 
       def show_latest_transaction_for(order)
-        taxjar_client.show_order order.number
+        latest_transaction_id =
+          OrderTransaction.latest_for(order)&.transaction_id
+
+        if latest_transaction_id.nil?
+          raise StandardError, "No latest TaxJar order transaction for #{order.number}"
+        end
+
+        taxjar_client.show_order(latest_transaction_id)
       end
 
       def create_refund_transaction_for(order)

--- a/lib/super_good/solidus_taxjar/testing_support/factories/order_transaction_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/order_transaction_factory.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :taxjar_order_transaction, class: "SuperGood::SolidusTaxjar::OrderTransaction" do
+    order
+    transaction_date { Date.current }
+
+    sequence(:transaction_id) { |n|
+      if n == 1
+        order.number
+      else
+        "#{order.number}-#{n - 1}"
+      end
+    }
+  end
+end

--- a/spec/models/super_good/solidus_taxjar/order_transaction_spec.rb
+++ b/spec/models/super_good/solidus_taxjar/order_transaction_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::OrderTransaction do
+  describe ".latest_for" do
+    subject { described_class.latest_for(order) }
+
+    let(:order) { create(:order) }
+
+    context "when there are no order transactions" do
+      it { is_expected.to be_nil }
+    end
+
+    context "when there are one or more order transactions" do
+      let!(:first_order_transaction) {
+        create(
+          :taxjar_order_transaction,
+          transaction_date: 2.days.ago,
+          order: order
+        )
+      }
+      let!(:latest_order_transaction) {
+        create(
+          :taxjar_order_transaction,
+          transaction_date: 1.days.ago,
+          order: order
+        )
+      }
+
+      it "returns the most recent order transaction" do
+        expect(subject).to eq latest_order_transaction
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ require File.expand_path("dummy/config/environment.rb", __dir__).tap { |file|
 
 require "solidus_dev_support/rspec/feature_helper"
 
+factories = Dir["#{::SuperGoodSolidusTaxjar::Engine.root}/lib/super_good/solidus_taxjar/testing_support/factories/**/*_factory.rb"].sort
+factories.each { |f| require f }
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
What is the goal of this PR?
---
This change creates a new record with the `transaction_id` reference used to identify the Solidus order on TaxJar when we create a transaction for it through the reporting API. This is necessary in order for us to be able to fetch and update the transaction in the future, especially in the case when there are multiple transactions for the same Solidus order (due to refund and updates) where the `order.number` does not correspond to the `transaction_id` on TaxJar.

How do you manually test these changes? (if applicable)
---

1. Create a transaction for a Solidus order using the `Api.create_transaction_for(order)` method
    * [x] Check that `order.taxjar_order_transactions` has a record containing the `transaction_id` and a `transaction_date`.
    * [x] Fetch the TaxJar order transaction using the  `Api.show_latest_transaction_for(order)` and ensure this returns the correct TaxJar order transaction.

Merge Checklist
---
- [x] Use the persisted `transaction_id` for refund calls
- [x] Run the manual tests
- [x] Update the Changelog
- [x] Run a sandbox app and verify taxes are being calculated

Relates to #101 