### PR TITLE
Create new transaction when shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#120](https://github.com/SuperGoodSoft/solidus_taxjar/pull/120) Change default `SOLIDUS_BRANCH` and `RAILS_VERSION`
 - [#109](https://github.com/SuperGoodSoft/solidus_taxjar/pull/109) Save `OrderTransaction` after API call to TaxJar
 - [#119](https://github.com/SuperGoodSoft/solidus_taxjar/pull/119) Move the install generator into the correct path so that it will be installed in the dummy app.
+- [#111](https://github.com/SuperGoodSoft/solidus_taxjar/pull/111) Create a new taxjar transaction when a shipment is shipped.
 
 ## v0.18.2
 

--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -1,0 +1,14 @@
+module SuperGood
+  module SolidusTaxjar
+    module Spree
+      module ReportingSubscriber
+        include ::Spree::Event::Subscriber
+        event_action :report_transaction, event_name: :shipment_shipped
+
+        def report_transaction(event)
+          SuperGood::SolidusTaxjar.reporting.report_transaction(event.payload[:shipment].order)
+        end
+      end
+    end
+  end
+end

--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -6,6 +6,7 @@ module SuperGood
         event_action :report_transaction, event_name: :shipment_shipped
 
         def report_transaction(event)
+          return unless SuperGood::SolidusTaxjar.reporting_enabled
           SuperGood::SolidusTaxjar.reporting.report_transaction(event.payload[:shipment].order)
         end
       end

--- a/lib/super_good/engine.rb
+++ b/lib/super_good/engine.rb
@@ -5,6 +5,11 @@ module SuperGoodSolidusTaxjar
     isolate_namespace Spree
     engine_name 'super_good_solidus_taxjar'
 
+    if Spree.solidus_gem_version < Gem::Version.new('2.11.0')
+      require root.join('app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber')
+      SuperGood::SolidusTaxjar::Spree::ReportingSubscriber.subscribe!
+    end
+
     include SolidusSupport::EngineExtensions
   end
 end

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -37,6 +37,10 @@ module SuperGood
       def table_name_prefix
         "solidus_taxjar_"
       end
+
+      def reporting
+        ::SuperGood::SolidusTaxjar::Reporting.new
+      end
     end
 
     self.cache_duration = 3.hours

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -11,6 +11,7 @@ require "super_good/solidus_taxjar/tax_calculator"
 require "super_good/solidus_taxjar/tax_rate_calculator"
 require "super_good/solidus_taxjar/discount_calculator"
 require "super_good/solidus_taxjar/addresses"
+require "super_good/solidus_taxjar/reporting"
 
 module SuperGood
   module SolidusTaxjar

--- a/lib/super_good/solidus_taxjar/reporting.rb
+++ b/lib/super_good/solidus_taxjar/reporting.rb
@@ -1,0 +1,17 @@
+module SuperGood
+  module SolidusTaxjar
+    class Reporting
+      def initialize(api: SuperGood::SolidusTaxjar.api)
+        @api = api
+      end
+
+      def report_transaction(order)
+        begin
+          @api.show_latest_transaction_for(order)
+        rescue Taxjar::Error::NotFound
+          @api.create_transaction_for(order)
+        end
+      end
+    end
+  end
+end

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
+  describe "shipment_shipped is fired" do
+    subject { ::Spree::Event.fire 'shipment_shipped', shipment: shipment  }
+
+    let(:shipment) { create(:shipment, state: 'ready', order: order) }
+    let(:order) { create :order_with_line_items }
+
+    it "reports transaction" do
+      reporting = instance_spy(::SuperGood::SolidusTaxjar::Reporting)
+
+      allow(::SuperGood::SolidusTaxjar)
+        .to receive(:reporting)
+        .and_return(reporting)
+
+      expect(reporting)
+        .to receive(:report_transaction)
+        .with(shipment.order)
+
+      subject
+    end
+  end
+end

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -4,21 +4,47 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
   describe "shipment_shipped is fired" do
     subject { ::Spree::Event.fire 'shipment_shipped', shipment: shipment  }
 
-    let(:shipment) { create(:shipment, state: 'ready', order: order) }
-    let(:order) { create :order_with_line_items }
+    let(:shipment) { build_stubbed(:shipment, state: 'ready', order: order) }
+    let(:order) { build_stubbed :order_with_line_items }
+    let(:reporting) { instance_spy(::SuperGood::SolidusTaxjar::Reporting) }
 
-    it "reports transaction" do
-      reporting = instance_spy(::SuperGood::SolidusTaxjar::Reporting)
+    context "reporting is enabled" do
+      before do
+        allow(::SuperGood::SolidusTaxjar)
+          .to receive(:reporting_enabled)
+          .and_return(true)
 
-      allow(::SuperGood::SolidusTaxjar)
-        .to receive(:reporting)
-        .and_return(reporting)
+        allow(::SuperGood::SolidusTaxjar)
+          .to receive(:reporting)
+          .and_return(reporting)
+      end
 
-      expect(reporting)
-        .to receive(:report_transaction)
-        .with(shipment.order)
+      it "reports transaction" do
+        expect(reporting)
+          .to receive(:report_transaction)
+          .with(shipment.order)
 
-      subject
+        subject
+      end
+    end
+
+    context "reporting is disabled" do
+      before do
+        allow(::SuperGood::SolidusTaxjar)
+          .to receive(:reporting_enabled)
+          .and_return(false)
+      end
+
+      it "returns nothing" do
+        expect(subject).to be_nil
+      end
+
+      it "doesn't report the transaction" do
+        expect(reporting)
+          .to_not receive(:report_transaction)
+
+        subject
+      end
     end
   end
 end

--- a/spec/super_good/solidus_taxjar/reporting_spec.rb
+++ b/spec/super_good/solidus_taxjar/reporting_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::Reporting do
+  describe "#report_transaction" do
+    subject { described_class.new(api: dummy_api).report_transaction(order) }
+
+    let(:dummy_api) {
+      instance_double ::SuperGood::SolidusTaxjar::Api
+    }
+
+    let(:order) { build :order, completed_at: 1.days.ago }
+
+    it "updates the transaction" do
+      allow(dummy_api)
+        .to receive(:show_latest_transaction_for)
+        .with(order)
+        .and_return("UPDATED-TRANSACTION-ID")
+
+      expect(subject).to eq("UPDATED-TRANSACTION-ID")
+    end
+
+    context "order doesn't have a transaction" do
+      it "creates the transaction for it" do
+        allow(dummy_api)
+          .to receive(:show_latest_transaction_for)
+          .with(order)
+          .and_raise(Taxjar::Error::NotFound)
+
+        expect(dummy_api)
+          .to receive(:create_transaction_for)
+          .with(order)
+          .and_return({})
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe SuperGood::SolidusTaxjar do
     it { is_expected.to eq("solidus_taxjar_") }
   end
 
+  describe ".api" do
+    subject { described_class.api }
+
+    it "returns an instance of the api client" do
+      expect(subject).to be_a(SuperGood::SolidusTaxjar::Api)
+    end
+  end
+
+  describe ".reporting" do
+    subject { described_class.reporting }
+
+    it "creates a new reporting" do
+      expect(subject).to be_a(::SuperGood::SolidusTaxjar::Reporting)
+    end
+  end
+
   describe "configuration" do
     describe ".cache_key" do
       subject { described_class.cache_key.call(order) }


### PR DESCRIPTION
What is the goal of this PR?
---
When a shipment is shipped, if there is no transaction for that order, we create a new transaction. The second half of this issue will be completed in https://github.com/SuperGoodSoft/solidus_taxjar/issues/92


How do you manually test these changes? (if applicable)
---

1. Generate a sandbox app
    * [x] it generates
2. Mark a shipment as shipped
    * [x] creates a new transaction for the order

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

Screenshots
---
