### PR TITLE
Add refund transaction model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#107](https://github.com/SuperGoodSoft/solidus_taxjar/pull/107) Fix rails-engine binstub to point to correct engine entry point
 - [#108](https://github.com/SuperGoodSoft/solidus_taxjar/pull/108) Add new model associated with a `Spree::Order` to represent taxjar order creation transactions
 - [#117](https://github.com/SuperGoodSoft/solidus_taxjar/pull/117) Fix migration install
+- [#114](https://github.com/SuperGoodSoft/solidus_taxjar/pull/114) Add new model associated with a `SuperGood::SolidusTaxjar::OrderTransaction` to represent taxjar refund creation transactions
 
 ## v0.18.2
 

--- a/app/models/super_good/solidus_taxjar/refund_transaction.rb
+++ b/app/models/super_good/solidus_taxjar/refund_transaction.rb
@@ -1,0 +1,13 @@
+module SuperGood
+  module SolidusTaxjar
+    class RefundTransaction < ActiveRecord::Base
+      belongs_to :order_transaction
+
+      delegate :order, to: :order_transaction
+
+      validates_presence_of :order_transaction
+      validates_presence_of :transaction_id
+      validates_presence_of :transaction_date
+    end
+  end
+end

--- a/db/migrate/20211008175113_create_taxjar_refund_transaction.rb
+++ b/db/migrate/20211008175113_create_taxjar_refund_transaction.rb
@@ -1,0 +1,15 @@
+class CreateTaxjarRefundTransaction < ActiveRecord::Migration[5.0]
+  def change
+    create_table :solidus_taxjar_refund_transactions do |t|
+      t.references :order_transaction, index: { unique: true, name: :refund_transactions_orders_idx }
+      t.string :transaction_id, null: false, index: { unique: true }
+      t.datetime :transaction_date, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :solidus_taxjar_refund_transactions,
+      :solidus_taxjar_order_transactions,
+      column: :order_transaction_id
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

Refund transactions are all associated with order transactions, and we want to keep track of their relationship. We also need to keep track of whether a refund for a order transaction has been pushed to taxjar yet.


How do you manually test these changes? (if applicable)
---

1. Create a refund transaction
    * [x] Ensure the `order_transaction`, `transaction_id`, and `transaction_date` are required and validated
    * [x] Ensure the associations with `order` and `order_transaction` work 

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
- [ ] Run a sandbox app and verify taxes are being calculated
