### PR TITLE
[115] Add transaction date to `OrderTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#108](https://github.com/SuperGoodSoft/solidus_taxjar/pull/108) Add new model associated with a `Spree::Order` to represent taxjar order creation transactions
 - [#117](https://github.com/SuperGoodSoft/solidus_taxjar/pull/117) Fix migration install
 - [#114](https://github.com/SuperGoodSoft/solidus_taxjar/pull/114) Add new model associated with a `SuperGood::SolidusTaxjar::OrderTransaction` to represent taxjar refund creation transactions
+- [#116](https://github.com/SuperGoodSoft/solidus_taxjar/pull/116) Update the `OrderTransaction` model to record the transaction date.
 
 ## v0.18.2
 

--- a/app/models/super_good/solidus_taxjar/order_transaction.rb
+++ b/app/models/super_good/solidus_taxjar/order_transaction.rb
@@ -4,6 +4,7 @@ module SuperGood
       belongs_to :order, class_name: "Spree::Order"
 
       validates_presence_of :transaction_id
+      validates_presence_of :transaction_date
     end
   end
 end

--- a/db/migrate/20211008183858_add_transaction_date_to_order_transaction.rb
+++ b/db/migrate/20211008183858_add_transaction_date_to_order_transaction.rb
@@ -1,0 +1,5 @@
+class AddTransactionDateToOrderTransaction < ActiveRecord::Migration[5.0]
+  def change
+    add_column :solidus_taxjar_order_transactions, :transaction_date, :datetime, null: false
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

We cannot rely on the `updated_at` and `created_at` value on `OrderTransaction`s to know when the order was originally created in TaxJar. As such, we create a separate column now.

#115 

How do you manually test these changes? (if applicable)
---

1. Create an order transaction.
    * [x] Ensure that the `transaction_date` is validated
    * [x] Ensure you can create one with a `transaction_date`

Merge Checklist
---

- [x] Run the manual tests
- [x] Rebase on top of #111 to record the transaction date or vice versa
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated