### PR TITLE
Report transaction asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Only run tests against solidus 2.11. This also represents the drop of official support for solidus 2.9 and 2.10.
 - [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Run tests against the most up to date versions of solidus.
 - [#141](https://github.com/SuperGoodSoft/solidus_taxjar/pull/141) Handle unimplemented reporting features
+- [#129](https://github.com/SuperGoodSoft/solidus_taxjar/pull/129) Report transaction asynchronously when a shipment is shipped.
 
 ## v0.18.2
 

--- a/app/jobs/super_good/solidus_taxjar/report_transaction_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/report_transaction_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SuperGood
+  module SolidusTaxjar
+    class ReportTransactionJob < ApplicationJob
+      queue_as { SuperGood::SolidusTaxjar.job_queue }
+
+      def perform(order)
+        SuperGood::SolidusTaxjar.reporting.report_transaction(order)
+      end
+    end
+  end
+end

--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -7,7 +7,7 @@ module SuperGood
 
         def report_transaction(event)
           return unless SuperGood::SolidusTaxjar.reporting_enabled
-          SuperGood::SolidusTaxjar.reporting.report_transaction(event.payload[:shipment].order)
+          SuperGood::SolidusTaxjar::ReportTransactionJob.perform_later(event.payload[:shipment].order)
         end
       end
     end

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -21,6 +21,7 @@ module SuperGood
       attr_accessor :custom_order_params
       attr_accessor :discount_calculator
       attr_accessor :exception_handler
+      attr_accessor :job_queue
       attr_accessor :line_item_tax_label_maker
       attr_accessor :logging_enabled
       attr_accessor :reporting_enabled
@@ -53,6 +54,7 @@ module SuperGood
     self.exception_handler = ->(e) {
       Rails.logger.error "An error occurred while fetching TaxJar tax rates - #{e}: #{e.message}"
     }
+    self.job_queue = :default
     self.line_item_tax_label_maker = ->(taxjar_line_item, spree_line_item) { "Sales Tax" }
     self.logging_enabled = false
 

--- a/spec/jobs/super_good/solidus_taxjar/report_transaction_job_spec.rb
+++ b/spec/jobs/super_good/solidus_taxjar/report_transaction_job_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::ReportTransactionJob do
+  describe ".perform_later" do
+    subject { described_class.perform_later(order) }
+
+    let(:order) { create :order }
+    let(:mock_reporting) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
+
+    it "enqueues the job" do
+      assert_enqueued_with(job: described_class, args: [order]) do
+        subject
+      end
+    end
+
+    it "reports the transaction when it performs the job" do
+      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(mock_reporting)
+      expect(mock_reporting).to receive(:report_transaction).with(order)
+
+      perform_enqueued_jobs do
+        subject
+      end
+    end
+  end
+end

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -118,5 +118,11 @@ RSpec.describe SuperGood::SolidusTaxjar do
         expect(subject).to eq(10)
       end
     end
+
+    describe ".job_queue" do
+      subject { described_class.job_queue }
+
+      it { is_expected.to eq :default }
+    end
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---
To move the reporting of transactions to be performed asynchronously. Previous to this change, when a shipment was shipped, a new reporting transaction was created through API synchronously. This was not ideal because any errors would impact the transition of the shipment to `shipment_shipped`. We have an introduced an Active Job class for reporting, which can be used from other places as well.

How do you manually test these changes? (if applicable)
---

1. Create an order and mark a shipment as shipped
    * [ ] Assert that a `SuperGood::SolidusTaxjar::ReportTransactionJob` is queued for the order.
2. Perform the job 
    * [ ] Assert that the transaction was reported on Taxjar.

Merge Checklist
---

- [ ] Run the manual tests
- [x] Update the changelog
- [ ] Run a sandbox app and verify taxes are being calculated

Screenshots
---
