### PR TITLE
Run CI build against current versions of Solidus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,7 @@ jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
-      - checkout
-      - solidusio_extensions/test-branch:
-          branch: v2.11
-      - solidusio_extensions/store-test-results
+      - solidusio_extensions/run-tests
 
 workflows:
   "Run specs on supported Solidus versions":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#119](https://github.com/SuperGoodSoft/solidus_taxjar/pull/119) Move the install generator into the correct path so that it will be installed in the dummy app.
 - [#111](https://github.com/SuperGoodSoft/solidus_taxjar/pull/111) Create a new taxjar transaction when a shipment is shipped.
 - [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Only run tests against solidus 2.11. This also represents the drop of official support for solidus 2.9 and 2.10.
+- [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Run tests against the most up to date versions of solidus.
 
 ## v0.18.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,6 @@ branch = ENV.fetch("SOLIDUS_BRANCH", "v2.10")
 
 gem "solidus", github: "solidusio/solidus", branch: branch
 
-# Needed to help Bundler figure out how to resolve dependencies,
-# otherwise it takes forever to resolve them.
-# See https://github.com/bundler/bundler/issues/6677
-gem "rails", ENV.fetch("RAILS_VERSION", "~> 5.2")
-
 # Provides basic authentication functionality for testing parts of your engine
 gem "solidus_auth_devise"
 

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -35,10 +35,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
           .and_return(false)
       end
 
-      it "returns nothing" do
-        expect(subject).to be_nil
-      end
-
       it "doesn't report the transaction" do
         expect(reporting)
           .to_not receive(:report_transaction)

--- a/spec/super_good/solidus_taxjar/addresses_spec.rb
+++ b/spec/super_good/solidus_taxjar/addresses_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
         address1: "475 North Beverly Drive",
         city: "Los Angeles",
         country: country_us,
-        first_name: "Chuck",
-        last_name: "Schuldiner",
         phone: "1-250-555-4444",
         state: state_california,
         zipcode: "90210"
@@ -79,8 +77,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
             address1: "475 N Beverly Dr",
             city: "Beverly Hills",
             country: country_us,
-            first_name: "Chuck",
-            last_name: "Schuldiner",
             phone: "1-250-555-4444",
             state: state_california,
             zipcode: "90210-4606"
@@ -123,8 +119,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
             address1: "475 N Beverly Dr",
             city: "Beverly Hills",
             country: country_us,
-            first_name: "Chuck",
-            last_name: "Schuldiner",
             phone: "1-250-555-4444",
             state: state_california,
             zipcode: "90210-4606"
@@ -143,8 +137,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
         address1: "475 North Beverly Drive",
         city: "Los Angeles",
         country: country_us,
-        first_name: "Chuck",
-        last_name: "Schuldiner",
         phone: "1-250-555-4444",
         state: state_california,
         zipcode: "90210"
@@ -212,8 +204,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
             address1: "475 N Beverly Dr",
             city: "Beverly Hills",
             country: country_us,
-            first_name: "Chuck",
-            last_name: "Schuldiner",
             phone: "1-250-555-4444",
             state: state_california,
             zipcode: "90210-4606"
@@ -264,8 +254,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
             address1: "475 N Beverly Dr",
             city: "Beverly Hills",
             country: country_us,
-            first_name: "Chuck",
-            last_name: "Schuldiner",
             phone: "1-250-555-4444",
             state: state_california,
             zipcode: "90210-4606"
@@ -275,8 +263,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Addresses do
             address1: "473 N Beverly Dr",
             city: "Phoenix",
             country: country_us,
-            first_name: "Chuck",
-            last_name: "Schuldiner",
             phone: "1-250-555-4444",
             state: state_arizona,
             zipcode: "90213-1234"

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -29,14 +29,16 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
   end
 
   let(:ship_address) do
-    Spree::Address.create!(
+    create(
+      :address,
       address1: "475 N Beverly Dr",
+      address2: nil,
       city: "Los Angeles",
       country: country_us,
       first_name: "Chuck",
       last_name: "Schuldiner",
       phone: "1-250-555-4444",
-      state: state_california,
+      state_code: "CA",
       zipcode: "90210"
     )
   end
@@ -49,14 +51,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       name: "United States",
       numcode: 840,
       states_required: true
-    )
-  end
-
-  let(:state_california) do
-    Spree::State.create!(
-      abbr: "CA",
-      country: country_us,
-      name: "California"
     )
   end
 
@@ -435,13 +429,16 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
     context "with an address without a state" do
       let(:ship_address) do
-        Spree::Address.create!(
+        create(
+          :address,
           address1: "72 High St",
+          address2: nil,
           city: "Birmingham",
           country: country_uk,
           first_name: "Chuck",
           last_name: "Schuldiner",
           phone: "1-250-555-4444",
+          state: nil,
           state_name: "West Midlands",
           zipcode: "B4 7TA"
         )
@@ -471,7 +468,8 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
     context "an address with address2" do
       let(:ship_address) do
-        Spree::Address.create!(
+        create(
+          :address,
           address1: "1 World Trade CTR",
           address2: "STE 45A",
           city: "New York",
@@ -479,11 +477,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
           first_name: "Chuck",
           last_name: "Schuldiner",
           phone: "1-250-555-4444",
-          state: Spree::State.create!(
-            abbr: "NY",
-            country: country_us,
-            name: "New York"
-          ),
+          state_code: "NY",
           zipcode: "10007"
         )
       end

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       address2: nil,
       city: "Los Angeles",
       country: country_us,
-      first_name: "Chuck",
-      last_name: "Schuldiner",
       phone: "1-250-555-4444",
       state_code: "CA",
       zipcode: "90210"
@@ -435,8 +433,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
           address2: nil,
           city: "Birmingham",
           country: country_uk,
-          first_name: "Chuck",
-          last_name: "Schuldiner",
           phone: "1-250-555-4444",
           state: nil,
           state_name: "West Midlands",
@@ -474,8 +470,6 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
           address2: "STE 45A",
           city: "New York",
           country: country_us,
-          first_name: "Chuck",
-          last_name: "Schuldiner",
           phone: "1-250-555-4444",
           state_code: "NY",
           zipcode: "10007"

--- a/spec/super_good/solidus_taxjar/calculator_helper_spec.rb
+++ b/spec/super_good/solidus_taxjar/calculator_helper_spec.rb
@@ -33,11 +33,6 @@ RSpec.describe SuperGood::SolidusTaxjar::CalculatorHelper do
       it { is_expected.to eq(true) }
     end
 
-    context "with a missing firstname" do
-      let(:address) { build :address, firstname: nil }
-      it { is_expected.to eq(false) }
-    end
-
     context "with a missing state in DE" do
       let(:address) { build :address, country_iso_code: "DE", state: nil }
       it { is_expected.to eq(false) }

--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
     context "when the order has an incomplete tax address" do
       let(:address) do
         ::Spree::Address.new(
-          first_name: "Ronnie James",
           zipcode: nil,
           address1: nil,
           city: "Beverly Hills",
@@ -106,7 +105,6 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
     context "when the order has no line items" do
       let(:address) do
         ::Spree::Address.new(
-          first_name: "Ronnie James",
           zipcode: "90210",
           address1: "9900 Wilshire Blvd",
           city: "Beverly Hills",
@@ -127,7 +125,6 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
     context "when the API encounters an error" do
       let(:address) do
         ::Spree::Address.new(
-          first_name: "Ronnie James",
           zipcode: "90210",
           address1: "9900 Wilshire Blvd",
           city: "Beverly Hills",
@@ -159,7 +156,6 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
     context "when the order has a non-empty tax address" do
       let(:address) do
         ::Spree::Address.new(
-          first_name: "Ronnie James",
           zipcode: "90210",
           address1: "9900 Wilshire Blvd",
           city: "Beverly Hills",

--- a/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_rate_calculator_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxRateCalculator do
 
     let(:incomplete_address) do
       ::Spree::Address.new(
-        first_name: "Ronnie James",
         zipcode: nil,
         address1: nil,
         city: "Beverly Hills",

--- a/super_good-solidus_taxjar.gemspec
+++ b/super_good-solidus_taxjar.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "solidus_dev_support"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "vcr", "~> 4.0"


### PR DESCRIPTION
What is the goal of this PR?
---
This removes the lock we have on the Solidus extensions Orb version
which previous to this commit was running test only on "older" versions
of Solidus which were 2.9 and 2.10. With this change to the Orb version
as well as the switch to the "run-tests" command we will be running tests
against master, 3.1, 3.0 and 2.11 which are the officially supported versions
of Solidus currently.

How do you manually test these changes? (if applicable)
---

1. Create a PR
    * [x] Check that the tests passed on Circle.ci

Merge Checklist
---

- [ ] ~Run the manual tests~
- [x] Update the changelog
- [ ] ~Run a sandbox app and verify taxes are being calculated~
