### PR TITLE
Run CI build against solidus v2.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,16 @@
 version: 2.1
 orbs:
-  solidusio_extensions: solidusio/extensions@0.2.24
+  # Always run tests agains the versions of Solidus defined in the
+  # most recent version of the Orb.
+  solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
       - checkout
-      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/test-branch:
+          branch: v2.11
       - solidusio_extensions/store-test-results
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#109](https://github.com/SuperGoodSoft/solidus_taxjar/pull/109) Save `OrderTransaction` after API call to TaxJar
 - [#119](https://github.com/SuperGoodSoft/solidus_taxjar/pull/119) Move the install generator into the correct path so that it will be installed in the dummy app.
 - [#111](https://github.com/SuperGoodSoft/solidus_taxjar/pull/111) Create a new taxjar transaction when a shipment is shipped.
+- [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Only run tests against solidus 2.11. This also represents the drop of official support for solidus 2.9 and 2.10.
 
 ## v0.18.2
 


### PR DESCRIPTION
What is the goal of this PR?
---

This moves us in the direction of only testing against major solidus versions. This will unblock existing merges into master while we work on solidus 3.0 and 3.1 support so we can enable the appropriate tests #135 

Merge Checklist
---

- ~[ ] Run the manual tests~
- [ ] Update the changelog
- ~[ ] Run a sandbox app and verify taxes are being calculated~
