### PR TITLE
Handle unimplemented reporting features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#111](https://github.com/SuperGoodSoft/solidus_taxjar/pull/111) Create a new taxjar transaction when a shipment is shipped.
 - [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Only run tests against solidus 2.11. This also represents the drop of official support for solidus 2.9 and 2.10.
 - [#137](https://github.com/SuperGoodSoft/solidus_taxjar/pull/137) Run tests against the most up to date versions of solidus.
+- [#141](https://github.com/SuperGoodSoft/solidus_taxjar/pull/141) Handle unimplemented reporting features
 
 ## v0.18.2
 

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -60,7 +60,10 @@ module SuperGood
           OrderTransaction.latest_for(order)&.transaction_id
 
         if latest_transaction_id.nil?
-          raise StandardError, "No latest TaxJar order transaction for #{order.number}"
+          raise NotImplementedError,
+            "No latest TaxJar order transaction for #{order.number}. "       \
+            "Backfilling TaxJar transaction orders from Solidus is not yet " \
+            "implemented."
         end
 
         taxjar_client.show_order(latest_transaction_id)

--- a/lib/super_good/solidus_taxjar/reporting.rb
+++ b/lib/super_good/solidus_taxjar/reporting.rb
@@ -8,6 +8,12 @@ module SuperGood
       def report_transaction(order)
         begin
           @api.show_latest_transaction_for(order)
+        rescue NotImplementedError
+          # FIXME:
+          # We can stop rescuing from `NotImplementedError` once we have
+          # fleshed out and implemented functionality to correctly backfill
+          # TaxJar order transactions and
+          # `SuperGood::SolidusTaxjar::OrderTransaction` records.
         rescue Taxjar::Error::NotFound
           @api.create_transaction_for(order)
         end

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -226,8 +226,10 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
     context "without a persisted order transaction" do
       it "raises an exception" do
         expect { subject }.to raise_error(
-          StandardError,
-          "No latest TaxJar order transaction for R111222333"
+          NotImplementedError,
+          "No latest TaxJar order transaction for #{order.number}. "       \
+          "Backfilling TaxJar transaction orders from Solidus is not yet " \
+          "implemented."
         )
       end
     end
@@ -290,8 +292,10 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
     context "when no order transaction has been persisted" do
       it "raises an exception" do
         expect { subject }.to raise_error(
-          StandardError,
-          "No latest TaxJar order transaction for R111222333"
+          NotImplementedError,
+          "No latest TaxJar order transaction for #{order.number}. "       \
+          "Backfilling TaxJar transaction orders from Solidus is not yet " \
+          "implemented."
         )
       end
     end

--- a/spec/super_good/solidus_taxjar/reporting_spec.rb
+++ b/spec/super_good/solidus_taxjar/reporting_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
   describe "#report_transaction" do
     subject { described_class.new(api: dummy_api).report_transaction(order) }
 
-    let(:dummy_api) {
-      instance_double ::SuperGood::SolidusTaxjar::Api
-    }
-
+    let(:dummy_api) { instance_double ::SuperGood::SolidusTaxjar::Api }
     let(:order) { build :order, completed_at: 1.days.ago }
 
     it "updates the transaction" do
@@ -20,18 +17,33 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
     end
 
     context "order doesn't have a transaction" do
-      it "creates the transaction for it" do
-        allow(dummy_api)
-          .to receive(:show_latest_transaction_for)
-          .with(order)
-          .and_raise(Taxjar::Error::NotFound)
+      context "the Solidus application has no record of the transaction" do
+        it "does nothing (until this feature is implemented)" do
+          allow(dummy_api)
+            .to receive(:show_latest_transaction_for)
+            .with(order)
+            .and_raise(NotImplementedError)
 
-        expect(dummy_api)
-          .to receive(:create_transaction_for)
-          .with(order)
-          .and_return({})
+          expect(dummy_api).not_to receive(:create_transaction_for)
 
-        subject
+          subject
+        end
+      end
+
+      context "TaxJar has no record of the transaction" do
+        it "creates the transaction for it" do
+          allow(dummy_api)
+            .to receive(:show_latest_transaction_for)
+            .with(order)
+            .and_raise(Taxjar::Error::NotFound)
+
+          expect(dummy_api)
+            .to receive(:create_transaction_for)
+            .with(order)
+            .and_return({})
+
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
What is the goal of this PR?
---

**Stop errorring out when an order without `OrderTransaction`s is marked as shipped.**

If Solidus TaxJar's reporting functionality is enabled, and an order is shipped, the `Solidus::Event#shipment_shipped` event that fires causes an error. This is because we were not rescuing from the `StandardError` that notified end users that a reporting feature had not yet been implemented.

This error was unexpected and not handled gracefully. Until the reporting functionality has been completed, we want the `#shipment_shipped` event to *do nothing* if it hits an unimplemented feature's codepath.

How do you manually test these changes? (if applicable)
---

1. In the Solidus admin, mark an order as shipped.
    * [x] Watch the order shipment state change to "shipped".
    * [x] Do not get redirected to a `StandardError` page.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated
