### PR TITLE
Switch CI base Ruby image to use Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ orbs:
   # most recent version of the Orb.
   solidusio_extensions: solidusio/extensions@volatile
 
+executors:
+  base:
+    docker:
+      - image: cimg/ruby:2.7-browsers
+
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres


### PR DESCRIPTION
What is the goal of this PR?
---
We are seeing failures when running with ruby 2.5 from the
pry-stack_explorer and pry-byebug gems. This is an attempt to fix that.

How do you manually test these changes? (if applicable)
---

1. Do a thing
    * [ ] Assert a result

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
- [ ] Run a sandbox app and verify taxes are being calculated

Screenshots
---
