### PR TITLE
Remove `pry-stack_explorer` and `pry-byebug`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ end
 
 group :development, :test do
   gem "pry"
-  gem "pry-stack_explorer"
-  gem "pry-byebug"
 end
 
 gemspec


### PR DESCRIPTION
What is the goal of this PR?
---

Improve the success rate and reliability of our CI pipeline.

When we started using Solidus's supported CircleCI orbs to manage our CI pipeline, builds against Solidus `master` started to fail.

The errors in our CI output looked like this:

    Generating dummy Rails application...
      create  config/master.key
      /home/circleci/project/vendor/bundle/master/ruby/2.5.0/gems/
        pry-byebug-3.8.0/lib/pry-byebug/control_d_handler.rb:5:
      warning: control_d_handler's arity of 2 parameters was deprecated
      (eval_string, pry_instance). Now it gets passed just 1 parameter
      (pry_instance)
      rake aborted!
      NameError: uninitialized constant DidYouMean::PlainFormatter

We determined that `pry-stack_explorer` and `pry-byebug` require >= 2.6, but Solidus's CircleCI orbs use Ruby 2.5.x.

Removing these developer tools side-skirts the issue.

Co-Authored-By: Chris Todorov <chris@super.gd>



How do you manually test these changes? (if applicable)
---

N/A

Merge Checklist
---

- [x] Run the manual tests
- [ ] Update the changelog
- [x] Run a sandbox app and verify taxes are being calculated

