### PR TITLE
Run specs against solidus current and older

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,10 @@ jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
-      - solidusio_extensions/run-tests
+      - checkout
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/run-tests-solidus-current
+      - solidusio_extensions/store-test-results
 
 workflows:
   "Run specs on supported Solidus versions":


### PR DESCRIPTION
What is the goal of this PR?
---

Prior to this commit, each pull request would be run against three
versions of solidus: master, current, and older. While it is good to
stay up to date, master can change quite frequently, so we don't want to
run against master on each branch. Future commits may consider a cron
schedule for running against master.
