### PR TITLE
Add workflow to run against Solidus master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,13 @@ workflows:
   "Run specs on Solidus master":
     jobs:
       - run-specs-with-master
+  "Weekly run specs against master":
+    triggers:
+      - schedule:
+          cron: "0 0 * * 4" # every Thursday
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - run-specs-with-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,18 @@ jobs:
       - solidusio_extensions/run-tests-solidus-older
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/store-test-results
+  run-specs-with-master:
+    executor: solidusio_extensions/postgres
+    steps:
+      - checkout
+      - solidusio_extensions/run-tests-solidus-master
+      - solidusio_extensions/store-test-results
+
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs-with-postgres
+  "Run specs on Solidus master":
+    jobs:
+      - run-specs-with-master


### PR DESCRIPTION
What is the goal of this PR?
---

Now that previous commits have removed Solidus master from our main CI
workflow, we define a second workflow to run against Solidus master.
This workflow should be marked as optional to avoid blocking open pull
requests.
