### PR TITLE
Update to default solidus version to `solidus@3.1`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-branch = ENV.fetch("SOLIDUS_BRANCH", "v2.10")
+branch = ENV.fetch("SOLIDUS_BRANCH", "v3.1")
 
 gem "solidus", github: "solidusio/solidus", branch: branch
 


### PR DESCRIPTION
What is the goal of this PR?
---

We don't support 2.10 anymore so we should default to the most up to
date version possible.

Merge Checklist
---

- [ ] ~~Run the manual tests~~
- [ ] ~~Update the changelog~~
