### PR TITLE
Update sandbox bin stub for `solidus@3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#158](https://github.com/SuperGoodSoft/solidus_taxjar/pull/158) Update sandbox bin stub for `solidus@3`
 - [#88](https://github.com/SuperGoodSoft/solidus_taxjar/pull/88) Fire `shipment_shipped` event when any shipment on an order ships.
 - [#81](https://github.com/SuperGoodSoft/solidus_taxjar/pull/81) Add install generator
 - [#95](https://github.com/SuperGoodSoft/solidus_taxjar/pull/95) Only require "state" for Canadian and US addresses

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -67,11 +67,12 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate spree:install \
+unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with-authentication=false \
+  --payment-method=none \
   $@
 
 unbundled bundle exec rails generate solidus:auth:install


### PR DESCRIPTION
What is the goal of this PR?
---

In `solidus@3.0`, the install generator command has been renamed from
`spree:install` to `solidus:install`. This fixes sandbox generation on
`solidus@3` releases.

How do you manually test these changes? (if applicable)
---

- [ ] `bin/sandbox`
- [ ] Verify the Solidus install generator is run (migrations should be present in sandbox folder)

Note that the sandbox app still needs some attention to boot on `solidus@3` due to unregistered custom events.

Fixes #155.

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
