### PR TITLE
Add tax categories API endpoint wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#141](https://github.com/SuperGoodSoft/solidus_taxjar/pull/141) Handle unimplemented reporting features
 - [#129](https://github.com/SuperGoodSoft/solidus_taxjar/pull/129) Report transaction asynchronously when a shipment is shipped.
 - [#127](https://github.com/SuperGoodSoft/solidus_taxjar/pull/127) Add acceptance test for calculating taxes with the extension.
+- [#160](https://github.com/SuperGoodSoft/solidus_taxjar/pull/160) Add tax categories API endpoint wrapper
 
 ## v0.18.2
 

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -17,6 +17,10 @@ module SuperGood
         @taxjar_client = taxjar_client
       end
 
+      def tax_categories
+        taxjar_client.categories
+      end
+
       def tax_for(order)
         taxjar_client.tax_for_order(ApiParams.order_params(order)).tap do |taxes|
           next unless SuperGood::SolidusTaxjar.logging_enabled

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
     end
   end
 
+  describe "#tax_categories" do
+    subject { api.tax_categories }
+
+    let(:tax_categories) {
+      [
+        instance_double(Taxjar::Category, name: "Clothing"),
+        instance_double(Taxjar::Category, name: "Digital Goods")
+      ]
+    }
+
+    it "responds with a list of tax categories" do
+      allow(dummy_client).to receive(:categories).and_return(tax_categories)
+
+      expect(subject).to eq(tax_categories)
+    end
+  end
 
   describe "#tax_for" do
     subject { api.tax_for order }

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -1,6 +1,9 @@
 require "spec_helper"
 
 RSpec.describe SuperGood::SolidusTaxjar::Api do
+  let(:api) { described_class.new(taxjar_client: dummy_client) }
+  let(:dummy_client) { instance_double ::Taxjar::Client }
+
   describe ".new" do
     subject { described_class.new }
 
@@ -35,8 +38,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#tax_for" do
     subject { api.tax_for order }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:order) { Spree::Order.new }
 
     before do
@@ -57,8 +58,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "tax_rate_for" do
     subject { api.tax_rate_for address }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:address) { Spree::Address.new }
     let(:tax_rate) { 0.04 }
     let(:response) { double(rate: tax_rate) }
@@ -81,8 +80,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#tax_rates_for" do
     subject { api.tax_rates_for address }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:address) { Spree::Address.new }
 
     before do
@@ -103,8 +100,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#create_transaction_for" do
     subject { api.create_transaction_for order }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:order) { create :order, number: "R123" }
 
     let(:dummy_response) do
@@ -160,8 +155,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#update_transaction_for" do
     subject { api.update_transaction_for order }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:order) { Spree::Order.new }
 
     before do
@@ -182,8 +175,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#delete_transaction_for" do
     subject { api.delete_transaction_for order }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:order) { Spree::Order.new(number: "R111222333") }
 
     before do
@@ -199,8 +190,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#show_latest_transaction_for" do
     subject { api.show_latest_transaction_for order }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:order) { Spree::Order.new(number: "R111222333") }
 
     context "with a persisted order transaction" do
@@ -238,8 +227,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#create_refund_for" do
     subject { api.create_refund_for reimbursement }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:reimbursement) { Spree::Reimbursement.new }
 
     before do
@@ -260,8 +247,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#create_refund_transaction_for" do
     subject { api.create_refund_transaction_for order }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:order) { create(:order_ready_to_ship, number: "R111222333") }
 
     let(:taxjar_order) {
@@ -322,8 +307,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
   describe "#validate_spree_address" do
     subject { api.validate_spree_address spree_address }
 
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
     let(:spree_address) { build :address }
 
     before do
@@ -343,9 +326,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
 
   describe "#nexus_regions" do
     subject { api.nexus_regions }
-
-    let(:api) { described_class.new(taxjar_client: dummy_client) }
-    let(:dummy_client) { instance_double ::Taxjar::Client }
 
     before do
       allow(dummy_client)


### PR DESCRIPTION
What is the goal of this PR?
---

This pull request simply adds a new TaxJar API endpoint to our API wrapper.

For your convenience, [here's a link to the API documentation](https://developers.taxjar.com/api/reference/?ruby#categories) for the endpoint we're wrapping.

We will use this endpoint in some upcoming work, where we map Solidus tax categories to TaxJar tax categories.

How do you manually test these changes? (if applicable)
---

N/A

Merge Checklist
---

- [x] ~~Run the manual tests~~
- [ ] Update the changelog

