### PR TITLE
Register `shipment_shipped` event

### DIFF
--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -3,6 +3,10 @@ module SuperGood
     module Spree
       module ReportingSubscriber
         include ::Spree::Event::Subscriber
+
+        if ::Spree::Event.method_defined?(:register)
+          ::Spree::Event.register("shipment_shipped")
+        end
         event_action :report_transaction, event_name: :shipment_shipped
 
         def report_transaction(event)


### PR DESCRIPTION
What is the goal of this PR?
---

Our CI is failing on Solidus master, so we try to fix it by registering the `shipment_shipped` event. I don't think this event is in the right place yet, so looking for feedback on where others think it belongs.

