### PR TITLE
Fix flash message not displaying when updating configuration

### DIFF
--- a/app/views/spree/admin/taxjar_settings/edit.html.erb
+++ b/app/views/spree/admin/taxjar_settings/edit.html.erb
@@ -31,7 +31,7 @@
 <% end %>
 
 <% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
-  <%= form_with model: @configuration, url: admin_taxjar_settings_path, method: :put do |form| %>
+  <%= form_with model: @configuration, url: admin_taxjar_settings_path, method: :put, local: true do |form| %>
     <%= render "spree/admin/shared/preference_fields/boolean",
           attribute:  :preferred_reporting_enabled,
           label: "Transaction Sync",

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
 
         check "Transaction Sync"
         click_on "Update Configuration"
+        expect(page).to have_content("TaxJar settings updated!")
         expect(page).to have_field("Transaction Sync", checked: true)
       end
     end


### PR DESCRIPTION
What is the goal of this PR?
---

The flash message was not displayed when updating the Taxjar configuration due to obscure behavior of `form_with`

How do you manually test these changes? (if applicable)
---

1. Update the taxjar configuration 
    * [x] Ensure a flash message appears

Merge Checklist
---

- [x] Run the manual tests
- ~~[ ] Update the changelog~~
