### PR TITLE
Hide all reporting features behind API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#127](https://github.com/SuperGoodSoft/solidus_taxjar/pull/127) Add acceptance test for calculating taxes with the extension.
 - [#160](https://github.com/SuperGoodSoft/solidus_taxjar/pull/160) Add tax categories API endpoint wrapper
 - [#171](https://github.com/SuperGoodSoft/solidus_taxjar/pull/171) Display existing Nexus regions
+- [#170](https://github.com/SuperGoodSoft/solidus_taxjar/pull/170) Hide all reporting features behind API key
 
 ## v0.18.2
 

--- a/app/views/spree/admin/taxjar_settings/edit.html.erb
+++ b/app/views/spree/admin/taxjar_settings/edit.html.erb
@@ -25,19 +25,19 @@
   <% end %>
   </table>
   <a class="btn btn-primary" href="<%= spree.admin_taxjar_settings_sync_nexus_regions_path %>">Sync Nexus Regions</a>
+  <% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
+    <%= form_with model: @configuration, url: admin_taxjar_settings_path, method: :put, local: true do |form| %>
+      <%= render "spree/admin/shared/preference_fields/boolean",
+            attribute:  :preferred_reporting_enabled,
+            label: "Transaction Sync",
+            form: form
+      %>
+      <p>Sync orders and refund with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</p>
+      <%= form.submit %>
+    <% end %>
+  <% end %>
 <% else %>
   <p>You must provide a TaxJar API token to use this extension. You can sign up for TaxJar <%= link_to "here", "https://app.taxjar.com/api_sign_up", target: "_blank", rel: "noreferrer" %>. Please see the extension documentation for details on providing this token to the extension.</p>
   <p><i>For more help in aquiring a TaxJar API token, see <%= link_to "How do I get a TaxJar sales tax API token?", "https://support.taxjar.com/article/160-how-do-i-get-a-sales-tax-api-token", target: "_blank", rel: "noreferrer" %></i></p>
 <% end %>
 
-<% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
-  <%= form_with model: @configuration, url: admin_taxjar_settings_path, method: :put, local: true do |form| %>
-    <%= render "spree/admin/shared/preference_fields/boolean",
-          attribute:  :preferred_reporting_enabled,
-          label: "Transaction Sync",
-          form: form
-    %>
-    <p>Sync orders and refund with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</p>
-    <%= form.submit %>
-  <% end %>
-<% end %>

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
     context "Taxjar API token is set" do
       it "shows the settings page" do
         expect(page).not_to have_content "You must provide a TaxJar API token"
+        expect(page).to have_content "Transaction Sync"
         expect(page).to have_content("Nexus Regions")
         expect(page).not_to have_content("British Columbia")
         click_on "Sync Nexus Regions"
@@ -55,6 +56,11 @@ RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
 
         expect(page).to have_link(href: "https://app.taxjar.com/api_sign_up")
         expect(page).to have_link(href: "https://support.taxjar.com/article/160-how-do-i-get-a-sales-tax-api-token")
+      end
+
+      it "doesn't show any other TaxJar features" do
+        expect(page).not_to have_content("Transaction Sync")
+        expect(page).not_to have_content("Nexus Regions")
       end
     end
   end


### PR DESCRIPTION
What is the goal of this PR?
---

The TaxJar settings page should not show any features that rely on a
API key unless the API key is set.

How do you manually test these changes? (if applicable)
---

1. View the TaxJar settings page without an API key set
    * [x] It should show a the warning to provide a taxjar api key
2. View the TaxJar settings page with an API key set
    * [x] It should show the "Transaction Sync" feature

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog

