### PR TITLE
Display existing Nexus regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#129](https://github.com/SuperGoodSoft/solidus_taxjar/pull/129) Report transaction asynchronously when a shipment is shipped.
 - [#127](https://github.com/SuperGoodSoft/solidus_taxjar/pull/127) Add acceptance test for calculating taxes with the extension.
 - [#160](https://github.com/SuperGoodSoft/solidus_taxjar/pull/160) Add tax categories API endpoint wrapper
+- [#171](https://github.com/SuperGoodSoft/solidus_taxjar/pull/171) Display existing Nexus regions
 
 ## v0.18.2
 

--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class TaxjarSettingsController < Spree::Admin::BaseController
       def edit
         @configuration = SuperGood::SolidusTaxjar.configuration
+        @nexus_regions = Rails.cache.fetch(:nexus_regions) || []
       end
 
       def update
@@ -10,6 +11,22 @@ module Spree
           flash[:success] = "TaxJar settings updated!"
         else
           flash[:alert] = "Failed to update settings!"
+        end
+        redirect_back(fallback_location: spree.admin_taxjar_settings_path)
+      end
+
+      def sync_nexus_regions
+        if ENV["TAXJAR_API_KEY"]
+          begin
+            Rails.cache.write(
+              :nexus_regions,
+              SuperGood::SolidusTaxjar.api.nexus_regions,
+              expires_in: 2.hours
+            )
+            flash[:success] = "Updated with new Nexus Regions"
+          rescue Taxjar::Error => exception
+            flash[:error] = exception.message
+          end
         end
         redirect_back(fallback_location: spree.admin_taxjar_settings_path)
       end

--- a/app/views/spree/admin/taxjar_settings/edit.html.erb
+++ b/app/views/spree/admin/taxjar_settings/edit.html.erb
@@ -5,8 +5,26 @@
 <% end %>
 
 <% if ENV["TAXJAR_API_KEY"] %>
+  <h2>Nexus Regions</h2>
   <table>
+  <thead>
+    <tr>
+      <th>Country Code</th>
+      <th>Country</th>
+      <th>Region Code</th>
+      <th>Region</th>
+    </tr>
+  </thead>
+  <% @nexus_regions.each do |region| %>
+    <tr>
+      <td><%= region.country_code %></td>
+      <td><%= region.country %></td>
+      <td><%= region.region_code %></td>
+      <td><%= region.region %></td>
+    </tr>
+  <% end %>
   </table>
+  <a class="btn btn-primary" href="<%= spree.admin_taxjar_settings_sync_nexus_regions_path %>">Sync Nexus Regions</a>
 <% else %>
   <p>You must provide a TaxJar API token to use this extension. You can sign up for TaxJar <%= link_to "here", "https://app.taxjar.com/api_sign_up", target: "_blank", rel: "noreferrer" %>. Please see the extension documentation for details on providing this token to the extension.</p>
   <p><i>For more help in aquiring a TaxJar API token, see <%= link_to "How do I get a TaxJar sales tax API token?", "https://support.taxjar.com/article/160-how-do-i-get-a-sales-tax-api-token", target: "_blank", rel: "noreferrer" %></i></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@
 Spree::Core::Engine.routes.draw do
   namespace :admin do
     resource :taxjar_settings, only: [:edit, :update]
+    get 'taxjar_settings/sync_nexus_regions', to: 'taxjar_settings#sync_nexus_regions'
   end
 end

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.feature 'Admin TaxJar Settings', js: true do
+RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
   stub_authorization!
 
   background do
@@ -8,7 +8,7 @@ RSpec.feature 'Admin TaxJar Settings', js: true do
   end
 
   describe "Taxjar settings tab" do
-    let(:api_token) { "token" }
+    let(:api_token) { ENV.fetch("TAXJAR_API_KEY", "fake_token") }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -37,8 +37,13 @@ RSpec.feature 'Admin TaxJar Settings', js: true do
     end
 
     context "Taxjar API token is set" do
-      it "shows a blank settings page" do
+      it "shows the settings page" do
         expect(page).not_to have_content "You must provide a TaxJar API token"
+        expect(page).to have_content("Nexus Regions")
+        expect(page).not_to have_content("British Columbia")
+        click_on "Sync Nexus Regions"
+        expect(page).to have_content("Updated with new Nexus Regions")
+        expect(page).to have_content("British Columbia")
       end
     end
 

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -31,7 +31,6 @@ RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
 
         check "Transaction Sync"
         click_on "Update Configuration"
-        visit current_path
         expect(page).to have_field("Transaction Sync", checked: true)
       end
     end

--- a/spec/fixtures/cassettes/Admin_TaxJar_Settings/Taxjar_settings_tab/Taxjar_API_token_is_set/shows_the_settings_page.yml
+++ b/spec/fixtures/cassettes/Admin_TaxJar_Settings/Taxjar_settings_tab/Taxjar_API_token_is_set/shows_the_settings_page.yml
@@ -1,0 +1,223 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin MacBook-Pro.hitronhub.home 21.2.0 Darwin Kernel Version
+        21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+        x86_64; ruby 2.6.6-p146; OpenSSL 1.1.1m  14 Dec 2021) taxjar-ruby/3.0.2'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '277'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Feb 2022 19:05:43 GMT
+      X-Amzn-Requestid:
+      - c115e204-2da1-4c4f-8a6f-812c62062eed
+      X-Amz-Apigw-Id:
+      - NpipOHfOoAMFmCg=
+      X-Amzn-Trace-Id:
+      - Root=1-620d4b07-225913c229f5a88b65fd6f36
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ae06b19943a6bad1c1b12b79f7339498.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA19-C3
+      X-Amz-Cf-Id:
+      - _87jwDiFvnDXNSDNMCaNT67Cq4AUP5XsO8dgzFGbX5LM9qK0N3xNzw==
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"region_code":"BC","region":"British Columbia","country_code":"CA","country":"Canada"},{"region_code":"CA","region":"California","country_code":"US","country":"United
+        States"},{"region_code":"NY","region":"New York","country_code":"US","country":"United
+        States"}]}'
+    http_version:
+  recorded_at: Wed, 16 Feb 2022 19:05:43 GMT
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin MacBook-Pro.hitronhub.home 21.2.0 Darwin Kernel Version
+        21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+        x86_64; ruby 2.6.6-p146; OpenSSL 1.1.1m  14 Dec 2021) taxjar-ruby/3.0.2'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '277'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Feb 2022 19:05:45 GMT
+      X-Amzn-Requestid:
+      - aca24973-b4eb-4a51-ad50-dbdb827afae8
+      X-Amz-Apigw-Id:
+      - NpiphG5JoAMFg6w=
+      X-Amzn-Trace-Id:
+      - Root=1-620d4b09-724d75cb4d6c2cf74fbfdb9b
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1f41b5f27f3ec2e93db2155dbc56900c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA19-C3
+      X-Amz-Cf-Id:
+      - 1RI42feI6GRc-JvGRgfeqW7UtWEN27GGE9PLsNxdEoANyZ1da3s5kg==
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"region_code":"BC","region":"British Columbia","country_code":"CA","country":"Canada"},{"region_code":"CA","region":"California","country_code":"US","country":"United
+        States"},{"region_code":"NY","region":"New York","country_code":"US","country":"United
+        States"}]}'
+    http_version:
+  recorded_at: Wed, 16 Feb 2022 19:05:45 GMT
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin MacBook-Pro.hitronhub.home 21.2.0 Darwin Kernel Version
+        21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+        x86_64; ruby 2.6.6-p146; OpenSSL 1.1.1m  14 Dec 2021) taxjar-ruby/3.0.2'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '277'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Feb 2022 19:05:48 GMT
+      X-Amzn-Requestid:
+      - 7ce419e9-f8f2-46d4-9caa-08af15ca95d1
+      X-Amz-Apigw-Id:
+      - Npip7EHNIAMFRbA=
+      X-Amzn-Trace-Id:
+      - Root=1-620d4b0c-606c6896015b79d873567533
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a9e73292d0b92053c3e38dcec15fd0e2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA19-C3
+      X-Amz-Cf-Id:
+      - 8QPS2lmr4ssZdm_yziyqCHJsXErDRJH3v7Mk-QjLhlzbo3OD0RHHNg==
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"region_code":"BC","region":"British Columbia","country_code":"CA","country":"Canada"},{"region_code":"CA","region":"California","country_code":"US","country":"United
+        States"},{"region_code":"NY","region":"New York","country_code":"US","country":"United
+        States"}]}'
+    http_version:
+  recorded_at: Wed, 16 Feb 2022 19:05:48 GMT
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin MacBook-Pro.hitronhub.home 21.2.0 Darwin Kernel Version
+        21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+        x86_64; ruby 2.6.6-p146; OpenSSL 1.1.1m  14 Dec 2021) taxjar-ruby/3.0.2'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '277'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Feb 2022 19:05:50 GMT
+      X-Amzn-Requestid:
+      - 647305bf-f303-4ab8-bd7f-10769927dba8
+      X-Amz-Apigw-Id:
+      - NpiqPGM-IAMFliA=
+      X-Amzn-Trace-Id:
+      - Root=1-620d4b0e-2dab60b437f1a21222b45d49
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 6bdc2963c9ed59b475ec36c35e5932a4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA19-C3
+      X-Amz-Cf-Id:
+      - cAVmcW2057d2pagrCyIeQk40aTPmCc5TbrCWL-8uhcoFZjLRMAJy0Q==
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"region_code":"BC","region":"British Columbia","country_code":"CA","country":"Canada"},{"region_code":"CA","region":"California","country_code":"US","country":"United
+        States"},{"region_code":"NY","region":"New York","country_code":"US","country":"United
+        States"}]}'
+    http_version:
+  recorded_at: Wed, 16 Feb 2022 19:05:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/cassettes/Admin_TaxJar_Settings/Taxjar_settings_tab/Taxjar_reporting_is_enabled/shows_that_reporting_is_enabled.yml
+++ b/spec/fixtures/cassettes/Admin_TaxJar_Settings/Taxjar_settings_tab/Taxjar_reporting_is_enabled/shows_that_reporting_is_enabled.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin MacBook-Pro.hitronhub.home 21.2.0 Darwin Kernel Version
+        21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64
+        x86_64; ruby 2.6.6-p146; OpenSSL 1.1.1m  14 Dec 2021) taxjar-ruby/3.0.2'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '277'
+      Connection:
+      - close
+      Date:
+      - Wed, 16 Feb 2022 19:05:40 GMT
+      X-Amzn-Requestid:
+      - c395ceb2-62ec-4f9b-839d-8a9b482026a3
+      X-Amz-Apigw-Id:
+      - NpiovG_VIAMF0yQ=
+      X-Amzn-Trace-Id:
+      - Root=1-620d4b04-6801a29a7e37dd427bd6a7e7
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ae06b19943a6bad1c1b12b79f7339498.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA19-C3
+      X-Amz-Cf-Id:
+      - zQxugXItdDwa7eNj4OTUQB2c7wdabn2nj0MW-9abeEokPBb1AOzKOw==
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"region_code":"BC","region":"British Columbia","country_code":"CA","country":"Canada"},{"region_code":"CA","region":"California","country_code":"US","country":"United
+        States"},{"region_code":"NY","region":"New York","country_code":"US","country":"United
+        States"}]}'
+    http_version:
+  recorded_at: Wed, 16 Feb 2022 19:05:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/requests/spree/admin/taxjar_settings_request_spec.rb
+++ b/spec/requests/spree/admin/taxjar_settings_request_spec.rb
@@ -11,6 +11,69 @@ RSpec.describe 'Admin TaxJar Settings', :type => :request do
     ActionController::Base.allow_forgery_protection = original
   end
 
+  describe "GET #sync_nexus_regions" do
+    subject { get spree.admin_taxjar_settings_sync_nexus_regions_path }
+
+    let(:dummy_api) { instance_double(SuperGood::SolidusTaxjar::Api) }
+
+    context "Taxjar API token is set" do
+      let(:api_token) { ENV.fetch("TAXJAR_API_KEY", "fake_token") }
+
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("TAXJAR_API_KEY").and_return(api_token)
+        allow(SuperGood::SolidusTaxjar).to receive(:api).and_return(dummy_api)
+        allow(dummy_api).to receive(:nexus_regions).and_return([])
+      end
+
+      it "makes a request for the nexus regions" do
+        subject
+        expect(dummy_api).to have_received(:nexus_regions)
+      end
+
+      it "redirects back to TaxJar settings" do
+        subject
+        expect(response).to redirect_to "/admin/taxjar_settings"
+      end
+
+      context "Taxjar call is successful" do
+        it "flashes a success alert" do
+          subject
+
+          expect(flash[:success]).to eq("Updated with new Nexus Regions")
+        end
+      end
+
+      context "Taxjar responds with an error" do
+        before do
+          allow(dummy_api).to receive(:nexus_regions).and_raise(Taxjar::Error, "fake error message")
+        end
+
+        it "flashes an error alert" do
+          subject
+
+          expect(flash[:error]).to eq("fake error message")
+        end
+      end
+    end
+
+    context "Taxjar API token is not set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("TAXJAR_API_KEY").and_return(nil)
+      end
+
+      it "doesn't make a request for the nexus regions" do
+        allow(SuperGood::SolidusTaxjar).to receive(:api).and_return(dummy_api)
+        allow(dummy_api).to receive(:nexus_regions).and_return([])
+
+        subject
+
+        expect(dummy_api).to_not have_received(:nexus_regions)
+      end
+    end
+  end
+
   describe "PUT #update" do
     subject { put spree.admin_taxjar_settings_path params:{ super_good_solidus_taxjar_configuration:{"preferred_reporting_enabled"=>true} }}
 


### PR DESCRIPTION
What is the goal of this PR?
---
Closes #156. The TaxJar settings tab in the Solidus Admin now displays the Nexus regions configured in TaxJar. The user can press the button to sync and cache the Nexus regions via the TaxJar API.  

How do you manually test these changes? (if applicable)
---

Not applicable; the feature test captures this.

Merge Checklist
---

- [x] Update the changelog

Screenshots
---

<img width="1186" alt="Screen Shot 2022-02-24 at 11 22 15 AM" src="https://user-images.githubusercontent.com/16298232/155592751-8f8f3468-c096-4334-81c9-30e5fef99020.png">

