### PR TITLE
Provide valid state and zip in address factory

### DIFF
--- a/lib/super_good/solidus_taxjar/testing_support/factories/address_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/address_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.modify do
+  # Solidus's default address factories provide an invalid state and zipcode
+  # combination.
+  factory :address do
+    zipcode { "11430" }
+
+    transient do
+      state_code { "NY" }
+    end
+  end
+end


### PR DESCRIPTION

What is the goal of this PR?
---
The zip code and state code provided by the default
factory were not a valid pair. This is fine for most tests, but causes
issues when making requests to TaxJar. To fix this, we provide a valid
New York zipcode.


How do you manually test these changes? (if applicable)
---

- [ ] Write a test that requires recording a TaxJar request with an address
- [ ] Verify the request doesn't error because of the zip/state
