### PR TITLE
Take adjustments into account in discount calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#174](https://github.com/SuperGoodSoft/solidus_taxjar/pull/174) Provide a link to Taxjar state settings
 - [#177](https://github.com/SuperGoodSoft/solidus_taxjar/pull/177) Make nexus caching configurable
 - [#169](https://github.com/SuperGoodSoft/solidus_taxjar/pull/169) Add basic backfill transaction functionality
+- [#181](https://github.com/SuperGoodSoft/solidus_taxjar/pull/181) Take all non-tax adjustment types into account when calculating a line item's discount
 
 ## v0.18.2
 

--- a/lib/super_good/solidus_taxjar/discount_calculator.rb
+++ b/lib/super_good/solidus_taxjar/discount_calculator.rb
@@ -6,7 +6,7 @@ module SuperGood
       end
 
       def discount
-        -line_item.promo_total
+        -1 * line_item.adjustments.select { |value| !value.tax? && value.eligible? }.sum(&:amount)
       end
 
       private

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
   describe ".order_params" do
     subject { described_class.order_params(order) }
 
+    before do
+      # The discount calculator relies on the line item adjustments existing in
+      # order to calculate the correct discount amount for TaxJar.
+      create(
+        :adjustment,
+        order: order,
+        adjustable: order.line_items.first,
+        amount: line_item_attributes[:promo_total],
+        source_type: "Spree::Promotion::Action::CreateItemAdjustments",
+        label: "Promo",
+        finalized: true # Prevents this adjustment from being recalculated.
+      )
+    end
+
     it "returns params for fetching the tax for the order" do
       expect(subject).to eq(
         customer_id: "12345",
@@ -268,6 +282,20 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
   describe ".transaction_params" do
     subject { described_class.transaction_params(order) }
+
+    before do
+      # The discount calculator relies on the line item adjustments existing in
+      # order to calculate the correct discount amount for TaxJar.
+      create(
+        :adjustment,
+        order: order,
+        adjustable: order.line_items.first,
+        amount: line_item_attributes[:promo_total],
+        source_type: "Spree::Promotion::Action::CreateItemAdjustments",
+        label: "Promo",
+        finalized: true # Prevents this adjustment from being recalculated.
+      )
+    end
 
     it "returns params for creating/updating an order transaction" do
       expect(subject).to eq({

--- a/spec/super_good/solidus_taxjar/discount_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/discount_calculator_spec.rb
@@ -5,9 +5,26 @@ RSpec.describe SuperGood::SolidusTaxjar::DiscountCalculator do
     subject { calculator.discount }
 
     let(:calculator) { described_class.new line_item }
+    let(:line_item) { create :line_item }
+    let!(:order) { create :completed_order_with_promotion, promotion: promotion_with_adjustment, line_items: [line_item] }
 
-    let(:line_item) { ::Spree::LineItem.new(promo_total: 12.34) }
+    let(:cancelation_adjustment_amount) { -8 }
+    let(:promotion_adjustment_amount) { -2 }
+    let(:promotion_with_adjustment) { create :promotion_with_item_adjustment, adjustment_rate: promotion_adjustment_amount }
+    let!(:unit_cancellation_adjustment) { create :adjustment, order: order, adjustable: line_item, amount: cancelation_adjustment_amount, source_type: "Spree::UnitCancel" }
 
-    it { is_expected.to eq(-12.34) }
+    let!(:tax_adjustment) { create :tax_adjustment, order: order, adjustable: line_item, amount: 2.50 }
+
+    it "sums the total of all non-tax adjustments" do
+      expect(subject).to eq(-1 * (cancelation_adjustment_amount + promotion_adjustment_amount))
+    end
+
+    context "a non-eligible adjustment exists" do
+      let!(:unit_cancellation_adjustment) { create :adjustment, order: order, adjustable: line_item, eligible: false, amount: cancelation_adjustment_amount, source_type: "Spree::UnitCancel" }
+
+      it "only sums eligible adjustments" do
+        expect(subject).to eq(-1 * promotion_adjustment_amount)
+      end
+    end
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

TaxJar requires the line item totals to match the order total when posting transactions. 

We need to ensure any adjustments that are not tax are included in the line item discount.

Merge Checklist
---

- [x] Run the manual tests
- [x] Run the scenario in https://github.com/SuperGoodSoft/solidus_taxjar/issues/184 and ensure it is fixed.
- [x] Update the changelog