### PR TITLE
Supply a default tax rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 - [#177](https://github.com/SuperGoodSoft/solidus_taxjar/pull/177) Make nexus caching configurable
 - [#169](https://github.com/SuperGoodSoft/solidus_taxjar/pull/169) Add basic backfill transaction functionality
 - [#181](https://github.com/SuperGoodSoft/solidus_taxjar/pull/181) Take all non-tax adjustment types into account when calculating a line item's discount
+- [#182](https://github.com/SuperGoodSoft/solidus_taxjar/pull/182) Automatically create default Tax Rate
+
+## Upgrading Instructions
+
+* If you had previously configured a `Spree::TaxRate` with the name "Sales Tax", it can be deleted after upgrading, as a new `Spree::TaxRate` with the name "Solidus TaxJar Rate" will automatically be created. Alternatively, you can rename your existing `Spree::TaxRate` from "Sales Tax" to "Solidus TaxJar Rate". [#182](https://github.com/SuperGoodSoft/solidus_taxjar/pull/182)
 
 ## v0.18.2
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ introduced in Solidus v2.4. This maps better to how the TaxJar API itself works.
     [Configuration](#configuration).
 
 1. Finally, make sure that the `TAXJAR_API_KEY` environment variable is set to
-  your TaxJar API key and make sure that you have a `Spree::TaxRate` with the name
-  "Sales Tax". This will be used as the source for the tax adjustments that
-  Solidus creates.
+  your TaxJar API key.
 
 ## Project Status
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Solidus < 2.11, so this extension provides a [compatibility layer](app/overrides
 breakdown for a given `Spree::Order`. The breakdown includes separate line items
 taxes and shipment taxes.
 
+This tax calculator will create a `Spree::TaxRate` that is required for tax adjustments. All other `Spree::TaxRate`s will be ignored in calculations. See [this wiki page](https://github.com/SuperGoodSoft/solidus_taxjar/wiki/How-Solidus-TaxJar-calculates-tax) for more details.
+
 ### TaxRateCalculator
 
 `SuperGood::SolidusTaxjar::TaxRateCalculator` allows calculating the tax rate

--- a/lib/super_good/solidus_taxjar/tax_calculator.rb
+++ b/lib/super_good/solidus_taxjar/tax_calculator.rb
@@ -109,8 +109,14 @@ module SuperGood
         )
       end
 
+      # Tax adjustments require an associated Tax Rate. This tax rate is not
+      # used in the extension's calculations as the rates from the TaxJar API
+      # are used, so a placeholder rate and calculator is created.
       def tax_rate
-        ::Spree::TaxRate.find_by(name: "Sales Tax")
+        ::Spree::TaxRate.find_or_create_by!(name: "Solidus TaxJar Rate") do |tax_rate|
+          tax_rate.calculator = ::Spree::Calculator.new
+          tax_rate.amount = 0
+        end
       end
 
       def cache_key

--- a/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
+++ b/spec/super_good/solidus_taxjar/tax_calculator_spec.rb
@@ -174,14 +174,6 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
       end
 
       context "and there is tax" do
-        let!(:tax_rate) do
-          ::Spree::TaxRate.create!(
-            name: "Sales Tax",
-            amount: 0.5,
-            calculator: ::Spree::Calculator.new
-          )
-        end
-
         let(:breakdown) do
           instance_double ::Taxjar::Breakdown,
             line_items: [taxjar_line_item],
@@ -205,7 +197,7 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
           aggregate_failures do
             expect(item_tax.item_id).to eq 33
             expect(item_tax.label).to eq "Sales Tax"
-            expect(item_tax.tax_rate).to eq tax_rate
+            expect(item_tax.tax_rate).to be_a(Spree::TaxRate)
             expect(item_tax.amount).to eq 6.66
             expect(item_tax.included_in_price).to eq false
           end
@@ -265,19 +257,19 @@ RSpec.describe ::SuperGood::SolidusTaxjar::TaxCalculator do
             aggregate_failures do
               expect(shipment_taxes[0].item_id).to eq 1
               expect(shipment_taxes[0].label).to eq "Sales Tax"
-              expect(shipment_taxes[0].tax_rate).to eq tax_rate
+              expect(shipment_taxes[0].tax_rate).to be_a(Spree::TaxRate)
               expect(shipment_taxes[0].amount).to eq 2.33
               expect(shipment_taxes[0].included_in_price).to eq false
 
               expect(shipment_taxes[1].item_id).to eq 2
               expect(shipment_taxes[1].label).to eq "Sales Tax"
-              expect(shipment_taxes[1].tax_rate).to eq tax_rate
+              expect(shipment_taxes[1].tax_rate).to be_a(Spree::TaxRate)
               expect(shipment_taxes[1].amount).to eq 4.33
               expect(shipment_taxes[1].included_in_price).to eq false
 
               expect(shipment_taxes[2].item_id).to eq 3
               expect(shipment_taxes[2].label).to eq "Sales Tax"
-              expect(shipment_taxes[2].tax_rate).to eq tax_rate
+              expect(shipment_taxes[2].tax_rate).to be_a(Spree::TaxRate)
               expect(shipment_taxes[2].amount).to eq 3.34
               expect(shipment_taxes[2].included_in_price).to eq false
             end


### PR DESCRIPTION
What is the goal of this PR?
---

All tax adjustments need a TaxRate as a source. Previously, we were relying on a user to have a tax rate with the name "Sales Tax" configured. This was an easy to miss configuration step. We should instead create the placeholder `Spree::TaxRate` desired with a descriptive name.

How do you manually test these changes? (if applicable)
---

1. Calculate some taxes
2. Visit the tax rates page of the admin
    * [x] Ensure the default rate is shown

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog

