### PR TITLE
Backfill transactions in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#185](https://github.com/SuperGoodSoft/solidus_taxjar/pull/185) Backfill transactions in batches
 - [#139](https://github.com/SuperGoodSoft/solidus_taxjar/pull/139) Refund and create a new order transaction when an order is recalculated
 - [#175](https://github.com/SuperGoodSoft/solidus_taxjar/pull/175) Add request logging to TaxJar API requests
 - [#138](https://github.com/SuperGoodSoft/solidus_taxjar/pull/138) Add admin UI for configuring reporting

--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -32,8 +32,8 @@ module Spree
       end
 
       def backfill_transactions
-        @backfilled_order_numbers = ::SuperGood::SolidusTaxjar::BackfillTransactions.new.call
-        flash[:success] = "Successfully backfilled transactions for #{@backfilled_order_numbers.count} orders."
+        @transaction_sync_batch = ::SuperGood::SolidusTaxjar::BackfillTransactions.new.call
+        flash[:success] = "Queued transaction backfill for #{@transaction_sync_batch.transaction_sync_logs.count} orders."
       end
 
       private

--- a/app/models/super_good/solidus_taxjar/transaction_sync_batch.rb
+++ b/app/models/super_good/solidus_taxjar/transaction_sync_batch.rb
@@ -1,0 +1,3 @@
+class SuperGood::SolidusTaxjar::TransactionSyncBatch < ApplicationRecord
+  has_many :transaction_sync_logs
+end

--- a/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
+++ b/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
@@ -1,0 +1,7 @@
+class SuperGood::SolidusTaxjar::TransactionSyncLog < ApplicationRecord
+  belongs_to :transaction_sync_batch
+  belongs_to :order, class_name: "Spree::Order"
+  belongs_to :order_transaction, optional: true
+
+  enum status: [:processing, :success, :error]
+end

--- a/app/views/spree/admin/taxjar_settings/backfill_transactions.html.erb
+++ b/app/views/spree/admin/taxjar_settings/backfill_transactions.html.erb
@@ -6,7 +6,7 @@
 
 <h2>Backfilled Orders</h2>
 <ul>
-  <% @backfilled_order_numbers.each do |order_number| %>
-    <li><%= order_number %></li>
+  <% @transaction_sync_batch.transaction_sync_logs.find_each do |sync_log| %>
+    <li><%= sync_log.order.number %></li>
   <% end %>
 </ul>

--- a/db/migrate/20220405213958_create_transaction_sync_batches.rb
+++ b/db/migrate/20220405213958_create_transaction_sync_batches.rb
@@ -1,0 +1,7 @@
+class CreateTransactionSyncBatches < ActiveRecord::Migration[5.0]
+  def change
+    create_table :solidus_taxjar_transaction_sync_batches do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220405215225_create_transaction_sync_logs.rb
+++ b/db/migrate/20220405215225_create_transaction_sync_logs.rb
@@ -1,0 +1,14 @@
+class CreateTransactionSyncLogs < ActiveRecord::Migration[5.0]
+  def change
+    create_table :solidus_taxjar_transaction_sync_logs do |t|
+      t.references :transaction_sync_batch, foreign_key: {to_table: :solidus_taxjar_transaction_sync_batches}, index: {name: "index_transaction_sync_logs_on_transaction_sync_batch_id"}, null: false
+      t.references :order, foreign_key: {to_table: :spree_orders}, null: false
+
+      t.references :order_transaction, foreign_key: {to_table: :solidus_taxjar_order_transactions}, index: {name: "index_transaction_sync_logs_on_order_transaction_id"}
+      t.integer :status, null: false, default: 0
+      t.string :error_message
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/super_good/solidus_taxjar/api.rb
+++ b/lib/super_good/solidus_taxjar/api.rb
@@ -42,15 +42,9 @@ module SuperGood
           current_transaction_id: latest_transaction_id
         )
 
-        response = taxjar_client.create_order(
+        taxjar_client.create_order(
           ApiParams.transaction_params(order, transaction_id)
         )
-
-        order.taxjar_order_transactions.create!(
-          transaction_id: response.transaction_id,
-          transaction_date: response.transaction_date
-        )
-        response
       end
 
       def update_transaction_for(order)

--- a/lib/super_good/solidus_taxjar/backfill_transactions.rb
+++ b/lib/super_good/solidus_taxjar/backfill_transactions.rb
@@ -6,7 +6,6 @@ module SuperGood
       end
 
       def call
-        backfilled_orders = []
         transaction_sync_batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.create!
 
         ::Spree::Order.complete.where(shipment_state: 'shipped').find_each do |order|
@@ -21,9 +20,9 @@ module SuperGood
           rescue Taxjar::Error => exception
             transaction_sync_log.update!(status: :error, error_message: exception.message)
           end
-          backfilled_orders.push(order.number)
         end
-        backfilled_orders
+
+        transaction_sync_batch
       end
 
       private

--- a/lib/super_good/solidus_taxjar/backfill_transactions.rb
+++ b/lib/super_good/solidus_taxjar/backfill_transactions.rb
@@ -7,9 +7,20 @@ module SuperGood
 
       def call
         backfilled_orders = []
+        transaction_sync_batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.create!
+
         ::Spree::Order.complete.where(shipment_state: 'shipped').find_each do |order|
           next if order.taxjar_order_transactions.any?
-          api.create_transaction_for(order)
+          transaction_sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
+            transaction_sync_batch: transaction_sync_batch,
+            order: order
+          )
+          begin
+            order_transaction = SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
+            transaction_sync_log.update!(order_transaction: order_transaction, status: :success)
+          rescue Taxjar::Error => exception
+            transaction_sync_log.update!(status: :error, error_message: exception.message)
+          end
           backfilled_orders.push(order.number)
         end
         backfilled_orders

--- a/lib/super_good/solidus_taxjar/reporting.rb
+++ b/lib/super_good/solidus_taxjar/reporting.rb
@@ -11,7 +11,10 @@ module SuperGood
       end
 
       def show_or_create_transaction(order)
-        @api.show_latest_transaction_for(order) || @api.create_transaction_for(order)
+        transaction_response = @api.show_latest_transaction_for(order) || @api.create_transaction_for(order)
+        SuperGood::SolidusTaxjar::OrderTransaction.find_by!(
+          transaction_id: transaction_response.transaction_id
+        )
       end
     end
   end

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
       scenario "the user backfills their transactions" do
         visit "/admin/taxjar_settings/edit"
         click_on "Backfill Transactions"
-        expect(page).to have_content("Successfully backfilled transactions for 1 orders.")
+        expect(page).to have_content("Queued transaction backfill for 1 orders.")
         expect(page).to have_content(order.number)
       end
     end

--- a/spec/requests/spree/admin/taxjar_settings_request_spec.rb
+++ b/spec/requests/spree/admin/taxjar_settings_request_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Admin TaxJar Settings', :vcr, :type => :request do
 
     it "shows a flash message" do
       subject
-      expect(flash[:success]).to eq "Successfully backfilled transactions for 1 orders."
+      expect(flash[:success]).to eq "Queued transaction backfill for 1 orders."
     end
 
     it "shows the backfilled orders" do

--- a/spec/super_good/solidus_taxjar/api_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_spec.rb
@@ -142,62 +142,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Api do
       end
 
       it { is_expected.to eq(dummy_response) }
-
-      it "creates an `OrderTransaction` for the order" do
-        expect { subject }
-          .to change { order.taxjar_order_transactions.count }
-          .from(0)
-          .to(1)
-      end
-
-      it "sets `transaction_id` and `transaction_date` on the order transaction" do
-        subject
-        expect(order.taxjar_order_transactions.first)
-          .to have_attributes(
-            transaction_id: "R123",
-            transaction_date: DateTime.new(2015, 5, 15, 0, 0, 0, "+0")
-          )
-      end
-    end
-
-    context "when the latest transaction ID is not the order number" do
-      before do
-        allow(dummy_client)
-          .to receive(:create_order)
-          .with(
-            SuperGood::SolidusTaxjar::ApiParams.transaction_params(
-              order,
-              "R123-1"
-            )
-          ).and_return(dummy_response)
-      end
-
-      let(:dummy_response) {
-        instance_double(
-          ::Taxjar::Order,
-          transaction_id: "R123-1",
-          transaction_date: "2015-05-15T00:00:00Z"
-        )
-      }
-
-      let!(:taxjar_order_transaction) {
-        create(
-          :taxjar_order_transaction,
-          order: order,
-          transaction_date: "2011-05-15T00:00:00Z"
-        )
-      }
-
-      it "creates a new TaxJar transaction with the next transaction ID" do
-        expect(order.taxjar_order_transactions)
-          .to receive(:create!)
-          .with(
-            transaction_id: "R123-1",
-            transaction_date: "2015-05-15T00:00:00Z"
-          )
-
-        subject
-      end
     end
 
     context "when the API call to create the transaction fails" do

--- a/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
+++ b/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactions do
     subject { described_class.new(api: api_spy).call }
 
     let!(:shipped_order) { create :shipped_order }
+    let(:reporting_mock) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
     let(:api_spy) { instance_spy(::SuperGood::SolidusTaxjar::Api) }
+    let(:test_transaction_id) { "R1234-transaction" }
 
     around do |example|
       ::SuperGood::SolidusTaxjar.test_mode = true
@@ -17,16 +19,64 @@ RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactions do
       reported_order = create :shipped_order
       create(:taxjar_order_transaction, order: reported_order)
       create :order_ready_to_ship
+
+      unreported_transaction = build(:taxjar_order_transaction, order: shipped_order, transaction_id: test_transaction_id)
+
+      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(reporting_mock)
+      allow(reporting_mock).to receive(:show_or_create_transaction) do
+        unreported_transaction.save!
+        unreported_transaction
+      end
     end
 
-    it "reports all completed and shipped orders to taxjar" do
+    it "reports the transaction to TaxJar" do
       subject
-      expect(api_spy).to have_received(:create_transaction_for).once
-      expect(api_spy).to have_received(:create_transaction_for).with(shipped_order)
+
+      expect(reporting_mock).to have_received(:show_or_create_transaction).with(shipped_order)
     end
 
     it "returns the numbers of the orders that have been pushed" do
       expect(subject).to eq([shipped_order.number])
+    end
+
+    it "creates a log of each synced order in the database" do
+      expect { subject }.to change { SuperGood::SolidusTaxjar::TransactionSyncBatch.count }
+        .from(0).to(1)
+      transaction_sync_batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.last
+      expect(transaction_sync_batch.transaction_sync_logs.count).to eq(1)
+      expect(transaction_sync_batch.transaction_sync_logs.last.order).to eq(shipped_order)
+    end
+
+    it "records the associated order, taxjar transaction, and status on each log" do
+      subject
+      sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.last
+
+      expect(sync_log).to have_attributes(
+        order: shipped_order,
+        status: "success"
+      )
+      expect(sync_log.order_transaction).not_to be_nil
+    end
+
+    context "when the transaction cannot be created on TaxJar" do
+      before do
+        allow(reporting_mock)
+          .to receive(:show_or_create_transaction)
+          .and_raise(Taxjar::Error.new("api down"))
+      end
+
+      it "records a failure status in the log" do
+        subject
+        sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.last
+
+        expect(sync_log).to have_attributes(
+          order: shipped_order,
+          status: "error",
+          error_message: /api down/
+        )
+
+        expect(sync_log.order_transaction).to be_nil
+      end
     end
   end
 end

--- a/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
+++ b/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactions do
       expect(reporting_mock).to have_received(:show_or_create_transaction).with(shipped_order)
     end
 
-    it "returns the numbers of the orders that have been pushed" do
-      expect(subject).to eq([shipped_order.number])
+    it "returns the associated transaction sync batch" do
+      expect(subject).to be_a(SuperGood::SolidusTaxjar::TransactionSyncBatch)
     end
 
     it "creates a log of each synced order in the database" do

--- a/spec/super_good/solidus_taxjar/reporting_spec.rb
+++ b/spec/super_good/solidus_taxjar/reporting_spec.rb
@@ -54,29 +54,80 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
   describe "#show_or_create_transaction" do
     subject { reporting.show_or_create_transaction(order) }
 
-    it "shows the latest transaction for the order" do
-      allow(dummy_api)
-        .to receive(:show_latest_transaction_for)
-        .with(order)
-        .and_return("UPDATED-TRANSACTION-ID")
+    context "the order has an existing transaction" do
+      let(:order) { build :order, completed_at: 1.days.ago }
+      let(:test_transaction_id) { "R1234-transaction" }
+      let(:test_transaction_date) { Date.new(2022, 1, 1) }
+      let(:taxjar_order_response_double) {
+        double(
+          "Taxjar::Order",
+          transaction_id: test_transaction_id,
+          transaction_date: test_transaction_date
+        )
+      }
 
-      expect(subject).to eq("UPDATED-TRANSACTION-ID")
+      before do
+        create :taxjar_order_transaction, transaction_id: test_transaction_id, transaction_date: test_transaction_date
+      end
+
+      it "returns the existing taxjar order transaction record" do
+        allow(dummy_api)
+          .to receive(:show_latest_transaction_for)
+          .and_return(taxjar_order_response_double)
+
+        subject
+
+        expect(dummy_api)
+          .to have_received(:show_latest_transaction_for)
+          .with(order)
+
+        expect(subject).to be_a(SuperGood::SolidusTaxjar::OrderTransaction)
+        expect(subject.persisted?).to be_truthy
+        expect(subject).to have_attributes(
+          transaction_id: test_transaction_id,
+          transaction_date: test_transaction_date
+        )
+      end
     end
 
     context "order doesn't have a transaction" do
+      let(:order) { create :order, completed_at: 1.days.ago }
+
       context "TaxJar has no record of the transaction" do
-        it "creates the transaction for it" do
+        let(:test_transaction_id) { "R1234-transaction" }
+        let(:test_transaction_date) { Date.new(2022, 1, 1) }
+        let(:taxjar_order_response_double) {
+          double(
+            "Taxjar::Order",
+            transaction_id: test_transaction_id,
+            transaction_date: test_transaction_date
+          )
+        }
+
+        it "creates a transaction for the order" do
           allow(dummy_api)
             .to receive(:show_latest_transaction_for)
-            .with(order)
             .and_return(nil)
 
-          expect(dummy_api)
-            .to receive(:create_transaction_for)
-            .with(order)
-            .and_return({})
+          allow(dummy_api)
+            .to receive(:create_transaction_for) do
+              # Currently, the API method is responsible for creating the transaction object, so
+              # we also have to mock out that behavior. This will be removed in an upcoming refactor.
+              create :taxjar_order_transaction, transaction_id: test_transaction_id, transaction_date: test_transaction_date
+              taxjar_order_response_double
+            end
 
           subject
+
+          expect(dummy_api).to have_received(:show_latest_transaction_for).with(order)
+          expect(dummy_api).to have_received(:create_transaction_for).with(order)
+
+          expect(subject).to be_a(SuperGood::SolidusTaxjar::OrderTransaction)
+          expect(subject.persisted?).to be_truthy
+          expect(subject).to have_attributes(
+            transaction_id: test_transaction_id,
+            transaction_date: test_transaction_date
+          )
         end
       end
     end


### PR DESCRIPTION
How do you manually test these changes? (if applicable)
---

1. Verify you have some orders that are ready for back-filling (e.g paid and shipped)
2. Verify the back-fill feature is enabled
3. Request a manual back-fill
4. Open a Rails console on the sandbox app to verify the new models were created (`TransactionSyncBatch` and `TransactionSyncLog`)

Merge Checklist
---

- [x] Update the changelog
- [ ] Run the manual tests