### PR TITLE
Show transaction sync batches in user interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#188](https://github.com/SuperGoodSoft/solidus_taxjar/pull/188) Show transaction sync batches in user interface
 - [#185](https://github.com/SuperGoodSoft/solidus_taxjar/pull/185) Backfill transactions in batches
 - [#139](https://github.com/SuperGoodSoft/solidus_taxjar/pull/139) Refund and create a new order transaction when an order is recalculated
 - [#175](https://github.com/SuperGoodSoft/solidus_taxjar/pull/175) Add request logging to TaxJar API requests

--- a/app/controllers/spree/admin/transaction_sync_batches_controller.rb
+++ b/app/controllers/spree/admin/transaction_sync_batches_controller.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Admin
+    class TransactionSyncBatchesController < Spree::Admin::BaseController
+      def index
+        @batches = SuperGood::SolidusTaxjar::TransactionSyncBatch.all
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/transaction_sync_batches_controller.rb
+++ b/app/controllers/spree/admin/transaction_sync_batches_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class TransactionSyncBatchesController < Spree::Admin::BaseController
       def index
-        @batches = SuperGood::SolidusTaxjar::TransactionSyncBatch.all
+        @batches = SuperGood::SolidusTaxjar::TransactionSyncBatch.all.page(params[:page]).per(params[:per_page])
       end
     end
   end

--- a/app/models/super_good/solidus_taxjar/transaction_sync_batch.rb
+++ b/app/models/super_good/solidus_taxjar/transaction_sync_batch.rb
@@ -1,3 +1,10 @@
 class SuperGood::SolidusTaxjar::TransactionSyncBatch < ApplicationRecord
   has_many :transaction_sync_logs
+
+  def status
+    return 'processing' if transaction_sync_logs.processing.any?
+    return 'error' if transaction_sync_logs.error.any?
+
+    'success'
+  end
 end

--- a/app/views/spree/admin/transaction_sync_batches/index.html.erb
+++ b/app/views/spree/admin/transaction_sync_batches/index.html.erb
@@ -1,0 +1,29 @@
+<%= render 'spree/admin/shared/taxes_tabs' %>
+
+<% content_for :page_title do %>
+  <%= "Transaction Sync Batches" %>
+<% end %>
+
+<table id="transaction_sync_batches">
+  <thead>
+    <tr>
+      <th>Batch ID</th>
+      <th>Created at</th>
+      <th>Updated at</th>
+      <th>Processed Orders</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @batches.each do |batch| %>
+      <tr>
+        <td><%= batch.id %></td>
+        <td><%= batch.created_at %></td>
+        <td><%= batch.updated_at %></td>
+        <td><%= batch.transaction_sync_logs.not_processing.count %>/<%= batch.transaction_sync_logs.count %></td>
+        <td><%= batch.status.capitalize %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/app/views/spree/admin/transaction_sync_batches/index.html.erb
+++ b/app/views/spree/admin/transaction_sync_batches/index.html.erb
@@ -27,3 +27,4 @@
   </tbody>
 </table>
 
+<%= paginate @batches, theme: "solidus_admin" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Spree::Core::Engine.routes.draw do
   namespace :admin do
     resource :taxjar_settings, only: [:edit, :update]
+    resources :transaction_sync_batches, only: [:index]
     get 'taxjar_settings/sync_nexus_regions', to: 'taxjar_settings#sync_nexus_regions'
     post 'taxjar_settings/backfill_transactions', to: 'taxjar_settings#backfill_transactions'
   end

--- a/lib/super_good/solidus_taxjar/testing_support/factories/transaction_sync_batch_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/transaction_sync_batch_factory.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :transaction_sync_batch, class: "SuperGood::SolidusTaxjar::TransactionSyncBatch" do
+    trait :with_logs do
+      after :build do |batch|
+        batch.transaction_sync_logs << build(:transaction_sync_log)
+      end
+    end
+  end
+end

--- a/lib/super_good/solidus_taxjar/testing_support/factories/transaction_sync_log_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/transaction_sync_log_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :transaction_sync_log, class: "SuperGood::SolidusTaxjar::TransactionSyncLog" do
+    order
+  end
+end

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.feature 'Admin Transaction Sync Batches', js: true do
+  stub_authorization!
+
+  background do
+    create :store, default: true
+  end
+
+  let!(:transaction_sync_batch) { create :transaction_sync_batch, :with_logs }
+
+  scenario "renders transaction backfill index" do
+    visit spree.admin_transaction_sync_batches_path
+    within "#transaction_sync_batches" do
+      expect(page).to have_content(transaction_sync_batch.id)
+      expect(page).to have_content(transaction_sync_batch.created_at)
+      expect(page).to have_content(transaction_sync_batch.updated_at)
+
+      within "tbody td:nth-child(4)" do
+        expect(page).to have_content("0/1")
+      end
+
+      within "tbody td:nth-child(5)" do
+        expect(page).to have_content("Processing")
+      end
+    end
+  end
+end

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -7,14 +7,34 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true do
     create :store, default: true
   end
 
-  let!(:transaction_sync_batch) { create :transaction_sync_batch, :with_logs }
+  let!(:transaction_sync_batches) { create_list :transaction_sync_batch, 2, :with_logs }
 
   scenario "renders transaction backfill index" do
-    visit spree.admin_transaction_sync_batches_path
+    visit spree.admin_transaction_sync_batches_path(per_page: 1)
+    transaction_sync_batch = transaction_sync_batches.first
     within "#transaction_sync_batches" do
       expect(page).to have_content(transaction_sync_batch.id)
       expect(page).to have_content(transaction_sync_batch.created_at)
       expect(page).to have_content(transaction_sync_batch.updated_at)
+
+      within "tbody td:nth-child(4)" do
+        expect(page).to have_content("0/1")
+      end
+
+      within "tbody td:nth-child(5)" do
+        expect(page).to have_content("Processing")
+      end
+    end
+
+    within ".pagination" do
+      click_on "Next"
+    end
+
+    second_transaction_sync_batch = transaction_sync_batches.second
+    within "#transaction_sync_batches" do
+      expect(page).to have_content(second_transaction_sync_batch.id)
+      expect(page).to have_content(second_transaction_sync_batch.created_at)
+      expect(page).to have_content(second_transaction_sync_batch.updated_at)
 
       within "tbody td:nth-child(4)" do
         expect(page).to have_content("0/1")

--- a/spec/models/super_good/solidus_taxjar/transaction_sync_batch_spec.rb
+++ b/spec/models/super_good/solidus_taxjar/transaction_sync_batch_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::TransactionSyncBatch do
+  describe "#status" do
+    subject { transaction_sync_batch.status }
+
+    let(:transaction_sync_batch) { create(:transaction_sync_batch, transaction_sync_logs: transaction_sync_logs) }
+
+    context "all logs have status 'success'" do
+      let(:transaction_sync_logs) { build_list(:transaction_sync_log, 2, status: :success) }
+
+      it "returns 'success'" do
+        expect(subject).to eq "success"
+      end
+    end
+
+    context "one or more logs have status 'error'" do
+      let(:transaction_sync_logs) { [
+        build(:transaction_sync_log, status: :success),
+        build(:transaction_sync_log, status: :error)
+      ] }
+
+      it "returns 'error'" do
+        expect(subject).to eq "error"
+      end
+    end
+
+    context "one or more logs have status 'processing'" do
+      let(:transaction_sync_logs) { [
+        build(:transaction_sync_log, status: :success),
+        build(:transaction_sync_log, status: :processing),
+        build(:transaction_sync_log, status: :error)
+      ] }
+
+      it "returns 'processing'" do
+        expect(subject).to eq "processing"
+      end
+    end
+
+    context "with an empty batch" do
+      let(:transaction_sync_logs) { [] }
+
+      it "returns 'success'" do
+        expect(subject).to eq "success"
+      end
+    end
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

Show the user the status of transaction sync batches

How do you manually test these changes? (if applicable)
---

1. Sync some orders to TaxJar
1. Visit `/admin/transaction_sync_batches` and verify a batch with a status is present

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog

Screenshots
---

![Screen Shot 2022-05-10 at 2 37 04 PM](https://user-images.githubusercontent.com/1747836/167726430-94a6efde-e5ef-41bf-9dd4-19c17c9f6d6a.png)

