### PR TITLE
[176] Create refund transaction models when reporting a refund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [#169](https://github.com/SuperGoodSoft/solidus_taxjar/pull/169) Add basic backfill transaction functionality
 - [#181](https://github.com/SuperGoodSoft/solidus_taxjar/pull/181) Take all non-tax adjustment types into account when calculating a line item's discount
 - [#182](https://github.com/SuperGoodSoft/solidus_taxjar/pull/182) Automatically create default Tax Rate
+- [#176](https://github.com/SuperGoodSoft/solidus_taxjar/pull/176) Create refund transaction database models when reporting refunds.
 
 ## Upgrading Instructions
 

--- a/app/models/super_good/solidus_taxjar/order_transaction.rb
+++ b/app/models/super_good/solidus_taxjar/order_transaction.rb
@@ -3,6 +3,8 @@ module SuperGood
     class OrderTransaction < ActiveRecord::Base
       belongs_to :order, class_name: "Spree::Order"
 
+      has_one :refund_transaction
+
       validates_presence_of :transaction_id
       validates_presence_of :transaction_date
 

--- a/lib/super_good/solidus_taxjar/reporting.rb
+++ b/lib/super_good/solidus_taxjar/reporting.rb
@@ -6,7 +6,12 @@ module SuperGood
       end
 
       def refund_and_create_new_transaction(order)
-        @api.create_refund_transaction_for(order)
+        transaction_response = @api.create_refund_transaction_for(order)
+        latest_order_transaction = OrderTransaction.latest_for(order)
+        latest_order_transaction.create_refund_transaction!(
+          transaction_id: transaction_response.transaction_id,
+          transaction_date: transaction_response.transaction_date
+        )
         if transaction_response = @api.create_transaction_for(order)
           order.taxjar_order_transactions.create!(
             transaction_id: transaction_response.transaction_id,

--- a/spec/fixtures/cassettes/SuperGood_SolidusTaxjar_Reporting/_refund_and_create_transaction/when_Taxjar_cannot_create_a_refund_transaction/doesn_t_create_a_new_transaction.yml
+++ b/spec/fixtures/cassettes/SuperGood_SolidusTaxjar_Reporting/_refund_and_create_transaction/when_Taxjar_cannot_create_a_refund_transaction/doesn_t_create_a_new_transaction.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://api.taxjar.com/v2/taxes
     body:
       encoding: UTF-8
-      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","line_items":[{"id":1,"quantity":1,"unit_price":"10.0","discount":"-0.0","product_tax_code":"TaxCode
-        - 514214"}],"shipping":"100.0"}'
+      string: '{"customer_id":"5","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
+        Different Road","line_items":[{"id":2,"quantity":1,"unit_price":"10.0","discount":0,"product_tax_code":"TaxCode
+        - 168268"}],"shipping":"100.0"}'
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -37,112 +37,40 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:49 GMT
+      - Mon, 18 Jul 2022 00:31:14 GMT
       X-Amzn-Requestid:
-      - 460fb8ca-2570-4a44-8892-4c548f8b1e86
+      - 14eaba84-0ff1-4793-a25d-acaab56399ac
       Access-Control-Allow-Origin:
       - https://developers.taxjar.com
       X-Amz-Apigw-Id:
-      - NtWaFEQlIAMF2bA=
+      - Vb943EvFIAMFkMA=
       X-Amzn-Trace-Id:
-      - Root=1-620ed10d-3d86387a11c36f2e11a0ef76
+      - Root=1-62d4a9d2-6381229c507254c561a09026
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 733ae4e17f2a4786e797d3450daabd46.cloudfront.net (CloudFront)
+      - 1.1 b47618c03bd47cf085f27b1e215f76cc.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - sn4iI6fHlTydVvuP_OYQJis8Q64y6k85mgar2BXXwHFooU7cA-WLBw==
+      - gByny7Nm3qHgUp-Zogb9e8jAV4UdnzvR4EdC9Hr29UH3Vpjl0UeoVA==
     body:
       encoding: UTF-8
-      string: '{"tax":{"amount_to_collect":9.76,"breakdown":{"city_tax_collectable":5.36,"city_tax_rate":0.04875,"city_taxable_amount":110.0,"combined_tax_rate":0.08875,"county_tax_collectable":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"line_items":[{"city_amount":0.49,"city_tax_rate":0.04875,"city_taxable_amount":10.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"id":"1","special_district_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_amount":0.4,"state_sales_tax_rate":0.04,"state_taxable_amount":10.0,"tax_collectable":0.89,"taxable_amount":10.0}],"shipping":{"city_amount":4.88,"city_tax_rate":0.04875,"city_taxable_amount":100.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_amount":4.0,"state_sales_tax_rate":0.04,"state_taxable_amount":100.0,"tax_collectable":8.88,"taxable_amount":100.0},"special_district_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_tax_collectable":4.4,"state_tax_rate":0.04,"state_taxable_amount":110.0,"tax_collectable":9.76,"taxable_amount":110.0},"freight_taxable":true,"has_nexus":true,"jurisdictions":{"city":"NEW
+      string: '{"tax":{"amount_to_collect":9.76,"breakdown":{"city_tax_collectable":5.36,"city_tax_rate":0.04875,"city_taxable_amount":110.0,"combined_tax_rate":0.08875,"county_tax_collectable":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"line_items":[{"city_amount":0.49,"city_tax_rate":0.04875,"city_taxable_amount":10.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"id":"2","special_district_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_amount":0.4,"state_sales_tax_rate":0.04,"state_taxable_amount":10.0,"tax_collectable":0.89,"taxable_amount":10.0}],"shipping":{"city_amount":4.88,"city_tax_rate":0.04875,"city_taxable_amount":100.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_amount":4.0,"state_sales_tax_rate":0.04,"state_taxable_amount":100.0,"tax_collectable":8.88,"taxable_amount":100.0},"special_district_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_tax_collectable":4.4,"state_tax_rate":0.04,"state_taxable_amount":110.0,"tax_collectable":9.76,"taxable_amount":110.0},"freight_taxable":true,"has_nexus":true,"jurisdictions":{"city":"NEW
         YORK CITY","country":"US","county":"QUEENS","state":"NY"},"order_total_amount":110.0,"rate":0.08875,"shipping":100.0,"tax_source":"destination","taxable_amount":110.0}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:49 GMT
-- request:
-    method: post
-    uri: https://api.taxjar.com/v2/transactions/orders
-    body:
-      encoding: UTF-8
-      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","line_items":[{"id":1,"quantity":1,"product_identifier":"SKU-2","description":"Product
-        #2 - 9838 - Master","product_tax_code":"TaxCode - 514214","unit_price":"10.0","discount":"-0.0","sales_tax":"0.89"}],"transaction_id":"R010654408","transaction_date":"2022-02-17T22:49:49Z","amount":"110.0","shipping":"100.0","sales_tax":"9.77"}'
-    headers:
-      User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
-      Authorization:
-      - Bearer <BEARER_TOKEN>
-      X-Api-Version:
-      - '2020-08-07'
-      Plugin:
-      - supergoodsolidustaxjar
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=UTF-8
-      Host:
-      - api.taxjar.com
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '643'
-      Connection:
-      - close
-      Date:
-      - Thu, 17 Feb 2022 22:49:49 GMT
-      X-Amzn-Requestid:
-      - 71ac36e8-f871-4096-9da3-fbb9bef47684
-      X-Amzn-Remapped-Content-Length:
-      - '643'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Request-Id:
-      - FtS0d4wnyM7rud1JPMBC
-      X-Api-Version:
-      - '2020-08-07'
-      X-Amz-Apigw-Id:
-      - NtWaIFB0IAMFcFg=
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Amzn-Remapped-Server:
-      - Cowboy
-      X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:49 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 f83d0d4febf7c22c3236bd42fa6dcd96.cloudfront.net (CloudFront)
-      X-Amz-Cf-Pop:
-      - YVR50-C1
-      X-Amz-Cf-Id:
-      - 5CitprWWphF0SwanJ7jzkorJg262ja9_1JL_mdjlGu3rs56Hljr6Qw==
-    body:
-      encoding: UTF-8
-      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R010654408","transaction_date":"2022-02-17T22:49:49.000Z","to_zip":"11430","to_street":"A
-        Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
-        - 514214","product_identifier":"SKU-2","id":0,"discount":"0.0","description":"Product
-        #2 - 9838 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
-    http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:49 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:13 GMT
 - request:
     method: get
-    uri: https://api.taxjar.com/v2/transactions/orders/R010654408
+    uri: https://api.taxjar.com/v2/transactions/orders/R1234-old-transaction
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -161,59 +89,56 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '643'
+      - '654'
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:49 GMT
+      - Mon, 18 Jul 2022 00:31:14 GMT
       X-Amzn-Requestid:
-      - 17158d67-2bf9-439f-be42-5c54e40a0958
+      - d3d82971-81c6-4147-9189-036e4c86c005
       X-Amzn-Remapped-Content-Length:
-      - '643'
+      - '654'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d5jh5AiICu9gdq-B
+      - FwLFDXaCyZ3sXToQEB5C
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWaKF43oAMF-NQ=
+      - Vb946EIcoAMFuZQ=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:49 GMT
+      - Mon, 18 Jul 2022 00:31:14 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 782cf460fc93d8eefdb183b4750900f2.cloudfront.net (CloudFront)
+      - 1.1 de8fc80b494d3d381f7e006918dcc588.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - R7gMLpx3taeFU87m0gXJcoyhhLRjt6gH0BJZihcr-wV_8Bjrxn5-AA==
+      - DJ3CXSpIRk7JCXI3ujiRIE4m-cPIlgDgOjAvtgh5ktZRwgmd5SIunw==
     body:
       encoding: UTF-8
-      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R010654408","transaction_date":"2022-02-17T22:49:49.000Z","to_zip":"11430","to_street":"A
+      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R1234-old-transaction","transaction_date":"2022-07-18T00:22:11.000Z","to_zip":"11430","to_street":"A
         Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
-        - 514214","product_identifier":"SKU-2","id":0,"discount":"0.0","description":"Product
-        #2 - 9838 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
+        - 703184","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 3375 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"4","amount":"110.0"}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:49 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:14 GMT
 - request:
-    method: post
-    uri: https://api.taxjar.com/v2/transactions/refunds
+    method: get
+    uri: https://api.taxjar.com/v2/transactions/refunds/R1234-old-transaction-REFUND
     body:
       encoding: UTF-8
-      string: '{"to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","transaction_id":"R010654408-REFUND","transaction_reference_id":"R010654408","transaction_date":"2022-02-17T22:49:49Z","amount":-110.0,"sales_tax":-9.77,"shipping":-100.0,"line_items":[{"unit_price":-10.0,"sales_tax":-0.89,"quantity":1,"product_tax_code":"TaxCode
-        - 514214","product_identifier":"SKU-2","id":0,"discount":-0.0,"description":"Product
-        #2 - 9838 - Master"}]}'
+      string: ''
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -222,68 +147,66 @@ http_interactions:
       - supergoodsolidustaxjar
       Connection:
       - close
-      Content-Type:
-      - application/json; charset=UTF-8
       Host:
       - api.taxjar.com
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '665'
+      - '687'
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:50 GMT
+      - Mon, 18 Jul 2022 00:31:14 GMT
       X-Amzn-Requestid:
-      - 00ab07ef-a018-4fc8-a920-cb9a02160226
+      - c94176b1-11b7-41f1-99f7-b3313f215964
       X-Amzn-Remapped-Content-Length:
-      - '665'
+      - '687'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d6r47bO_QK1gdPvB
+      - FwLFDYPA7yLdz85uNcdD
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWaNEfCIAMFXug=
+      - Vb948FMMoAMFzcQ=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:50 GMT
+      - Mon, 18 Jul 2022 00:31:14 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 87136170926d082ce5ff23d5ad5be32c.cloudfront.net (CloudFront)
+      - 1.1 f62c9ca47e35df5c65764381977823a6.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - LVunxnHMc_gzzuPZqC2v-h7GPY-IeFZgO34SRZ6lWB8fhNMhGdLMUQ==
+      - J-abAWMM_vejHFLC_XLGpfn9Vdgkwe8hIhun54uA_W0cJSrhzekKAQ==
     body:
       encoding: UTF-8
-      string: '{"refund":{"user_id":225397,"transaction_reference_id":"R010654408","transaction_id":"R010654408-REFUND","transaction_date":"2022-02-17T22:49:49.000Z","to_zip":"11430","to_street":"A
+      string: '{"refund":{"user_id":225397,"transaction_reference_id":"R1234-old-transaction","transaction_id":"R1234-old-transaction-REFUND","transaction_date":"2022-07-18T00:22:11.000Z","to_zip":"11430","to_street":"A
         Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"-100.0","sales_tax":"-9.77","provider":"api","line_items":[{"unit_price":"-10.0","sales_tax":"-0.89","quantity":1,"product_tax_code":"TaxCode
-        - 514214","product_identifier":"SKU-2","id":0,"discount":"0.0","description":"Product
-        #2 - 9838 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":null,"amount":"-110.0"}}'
+        - 703184","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 3375 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":null,"amount":"-110.0"}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:49 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:14 GMT
 - request:
     method: get
-    uri: https://api.taxjar.com/v2/transactions/orders/R010654408
+    uri: https://api.taxjar.com/v2/transactions/orders/R1234-old-transaction
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -302,59 +225,59 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '643'
+      - '654'
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:50 GMT
+      - Mon, 18 Jul 2022 00:31:15 GMT
       X-Amzn-Requestid:
-      - 5cdd8279-a608-480a-9873-fd8783e8605b
+      - f8566b49-6642-448b-b229-87e1a4fc1426
       X-Amzn-Remapped-Content-Length:
-      - '643'
+      - '654'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d7hZm4xMliMxI2bD
+      - FwLFDZiCr7ZcNPPQoaLB
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWaPGFDoAMFSdQ=
+      - Vb95AGNEIAMFTGQ=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:50 GMT
+      - Mon, 18 Jul 2022 00:31:15 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 0d5efb0576b3c35a58ca71a83003f34a.cloudfront.net (CloudFront)
+      - 1.1 f7283f3fe2c258cf54f8b7d3dd272e0e.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - _ZbTZQCLWEevJRnUvkLlfznLCH1C9imXAyEs6Ru9joATc71sLWXoMA==
+      - HQmjgkGKzLy9AOKXFPo1wkrZqqkEHMf6E_qnwsVo9JSokLMKPbKsIA==
     body:
       encoding: UTF-8
-      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R010654408","transaction_date":"2022-02-17T22:49:49.000Z","to_zip":"11430","to_street":"A
+      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R1234-old-transaction","transaction_date":"2022-07-18T00:22:11.000Z","to_zip":"11430","to_street":"A
         Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
-        - 514214","product_identifier":"SKU-2","id":0,"discount":"0.0","description":"Product
-        #2 - 9838 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
+        - 703184","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 3375 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"4","amount":"110.0"}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:50 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:14 GMT
 - request:
     method: post
     uri: https://api.taxjar.com/v2/transactions/refunds
     body:
       encoding: UTF-8
       string: '{"to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","transaction_id":"R010654408-REFUND","transaction_reference_id":"R010654408","transaction_date":"2022-02-17T22:49:49Z","amount":-110.0,"sales_tax":-9.77,"shipping":-100.0,"line_items":[{"unit_price":-10.0,"sales_tax":-0.89,"quantity":1,"product_tax_code":"TaxCode
-        - 514214","product_identifier":"SKU-2","id":0,"discount":-0.0,"description":"Product
-        #2 - 9838 - Master"}]}'
+        Different Road","transaction_id":"R1234-old-transaction-REFUND","transaction_reference_id":"R1234-old-transaction","transaction_date":"2022-07-18T00:31:14Z","amount":-110.0,"sales_tax":-9.77,"shipping":-100.0,"line_items":[{"unit_price":-10.0,"sales_tax":-0.89,"quantity":1,"product_tax_code":"TaxCode
+        - 703184","product_identifier":"SKU-1","id":0,"discount":-0.0,"description":"Product
+        #1 - 3375 - Master"}]}'
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -379,37 +302,37 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:50 GMT
+      - Mon, 18 Jul 2022 00:31:15 GMT
       X-Amzn-Requestid:
-      - 99d6aa52-b5d4-4173-8870-aa768984a485
+      - 1c7a3e71-f474-473a-baf7-cc8d13819b47
       X-Amzn-Remapped-Content-Length:
       - '110'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d8kMF5NMzr9Ht70C
+      - FwLFDbEFP5QKQKfQoaYB
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWaSElMIAMFYeQ=
+      - Vb95EHJDoAMFrHw=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:50 GMT
+      - Mon, 18 Jul 2022 00:31:15 GMT
       X-Cache:
       - Error from cloudfront
       Via:
-      - 1.1 d83887583c419ccbd4f595c44721b292.cloudfront.net (CloudFront)
+      - 1.1 e77661e211afe9242e85e573f12d5534.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - U5YAj6LnkiRUSnG9OdvW_tPi5fopwCGEANbmrv4vypJb910vKWy7fQ==
+      - uLA4Ha45xK5shnkFSZd1vwmM7y2qccsWY9Oi8z7YK1RdvkxEGSwJCA==
     body:
       encoding: UTF-8
       string: '{"status":422,"error":"Unprocessable Entity","detail":"Provider tranx
         already imported for your user account"}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:50 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:15 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/cassettes/SuperGood_SolidusTaxjar_Reporting/_refund_and_create_transaction/when_Taxjar_cannot_create_a_refund_transaction/raises_an_error.yml
+++ b/spec/fixtures/cassettes/SuperGood_SolidusTaxjar_Reporting/_refund_and_create_transaction/when_Taxjar_cannot_create_a_refund_transaction/raises_an_error.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://api.taxjar.com/v2/taxes
     body:
       encoding: UTF-8
-      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","line_items":[{"id":1,"quantity":1,"unit_price":"10.0","discount":"-0.0","product_tax_code":"TaxCode
-        - 99028"}],"shipping":"100.0"}'
+      string: '{"customer_id":"4","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
+        Different Road","line_items":[{"id":1,"quantity":1,"unit_price":"10.0","discount":0,"product_tax_code":"TaxCode
+        - 209957"}],"shipping":"100.0"}'
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -37,112 +37,40 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:47 GMT
+      - Mon, 18 Jul 2022 00:31:12 GMT
       X-Amzn-Requestid:
-      - dea967a5-ccb2-49b7-b988-fad968141e64
+      - 8d934833-fe8b-434b-a121-f9966955e697
       Access-Control-Allow-Origin:
       - https://developers.taxjar.com
       X-Amz-Apigw-Id:
-      - NtWZzF5foAMFSdQ=
+      - Vb94kHsOoAMFfrQ=
       X-Amzn-Trace-Id:
-      - Root=1-620ed10b-7e804f7050d46fbe096c7051
+      - Root=1-62d4a9d0-1928ca354bff9c5422aff84f
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 040bad3c7f7db09654c66da40c719fb0.cloudfront.net (CloudFront)
+      - 1.1 ece5d4a731ece5ff46c564ab2b946ede.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - OD2yia0GsS5BqZnX8e3dVd9-MXT4t1ITwZRqGJr5Rj_Np4Wk-fcR6A==
+      - Vhvx8YikD8wigmw_wAGGGUj9AKafNmq0CTlgSePCEsAAqeMiYevKMQ==
     body:
       encoding: UTF-8
       string: '{"tax":{"amount_to_collect":9.76,"breakdown":{"city_tax_collectable":5.36,"city_tax_rate":0.04875,"city_taxable_amount":110.0,"combined_tax_rate":0.08875,"county_tax_collectable":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"line_items":[{"city_amount":0.49,"city_tax_rate":0.04875,"city_taxable_amount":10.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"id":"1","special_district_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_amount":0.4,"state_sales_tax_rate":0.04,"state_taxable_amount":10.0,"tax_collectable":0.89,"taxable_amount":10.0}],"shipping":{"city_amount":4.88,"city_tax_rate":0.04875,"city_taxable_amount":100.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_amount":4.0,"state_sales_tax_rate":0.04,"state_taxable_amount":100.0,"tax_collectable":8.88,"taxable_amount":100.0},"special_district_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_tax_collectable":4.4,"state_tax_rate":0.04,"state_taxable_amount":110.0,"tax_collectable":9.76,"taxable_amount":110.0},"freight_taxable":true,"has_nexus":true,"jurisdictions":{"city":"NEW
         YORK CITY","country":"US","county":"QUEENS","state":"NY"},"order_total_amount":110.0,"rate":0.08875,"shipping":100.0,"tax_source":"destination","taxable_amount":110.0}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:47 GMT
-- request:
-    method: post
-    uri: https://api.taxjar.com/v2/transactions/orders
-    body:
-      encoding: UTF-8
-      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","line_items":[{"id":1,"quantity":1,"product_identifier":"SKU-1","description":"Product
-        #1 - 2950 - Master","product_tax_code":"TaxCode - 99028","unit_price":"10.0","discount":"-0.0","sales_tax":"0.89"}],"transaction_id":"R851261413","transaction_date":"2022-02-17T22:49:47Z","amount":"110.0","shipping":"100.0","sales_tax":"9.77"}'
-    headers:
-      User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
-      Authorization:
-      - Bearer <BEARER_TOKEN>
-      X-Api-Version:
-      - '2020-08-07'
-      Plugin:
-      - supergoodsolidustaxjar
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=UTF-8
-      Host:
-      - api.taxjar.com
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '642'
-      Connection:
-      - close
-      Date:
-      - Thu, 17 Feb 2022 22:49:47 GMT
-      X-Amzn-Requestid:
-      - 61ccc9e9-8858-4d23-bb87-825dda134175
-      X-Amzn-Remapped-Content-Length:
-      - '642'
-      X-Amzn-Remapped-Connection:
-      - keep-alive
-      X-Request-Id:
-      - FtS0dyMr9tYgMhVd0CZB
-      X-Api-Version:
-      - '2020-08-07'
-      X-Amz-Apigw-Id:
-      - NtWZ2EIXIAMF_rQ=
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Amzn-Remapped-Server:
-      - Cowboy
-      X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:47 GMT
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 ffe7114eb67ff864ff5a46aa2b63ce6e.cloudfront.net (CloudFront)
-      X-Amz-Cf-Pop:
-      - YVR50-C1
-      X-Amz-Cf-Id:
-      - s_RvjzqdZtOx4W7h03xEr5DRX5j2jkyuU8NvFFaKyL7GiC5ct-igcA==
-    body:
-      encoding: UTF-8
-      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R851261413","transaction_date":"2022-02-17T22:49:47.000Z","to_zip":"11430","to_street":"A
-        Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
-        - 99028","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
-        #1 - 2950 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
-    http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:47 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:12 GMT
 - request:
     method: get
-    uri: https://api.taxjar.com/v2/transactions/orders/R851261413
+    uri: https://api.taxjar.com/v2/transactions/orders/R1234-old-transaction
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -161,59 +89,56 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '642'
+      - '654'
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:12 GMT
       X-Amzn-Requestid:
-      - f19e47c8-3722-4c2e-9fcc-e4fae8ab532a
+      - 2cb852f2-a7cd-49b5-947d-168d275cd08e
       X-Amzn-Remapped-Content-Length:
-      - '642'
+      - '654'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0dzeqhggb7yxgdp1B
+      - FwLFDQYTa_280BAMgraC
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWZ6FcRoAMF8zw=
+      - Vb94nFgNIAMF4KQ=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:12 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 bf58b72d041cddee9bf926a00eeeb60a.cloudfront.net (CloudFront)
+      - 1.1 f7283f3fe2c258cf54f8b7d3dd272e0e.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - 8ccpUBJHwQlikB-_y9ayffv3bVY9jIsbAGqDbr0yHDlk5z9nc9pmPg==
+      - 89v6C3q1vGdjxrDja1GhsNvsfskvZpQXimXgmNKqUbf8D1xVIMn__A==
     body:
       encoding: UTF-8
-      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R851261413","transaction_date":"2022-02-17T22:49:47.000Z","to_zip":"11430","to_street":"A
+      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R1234-old-transaction","transaction_date":"2022-07-18T00:22:11.000Z","to_zip":"11430","to_street":"A
         Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
-        - 99028","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
-        #1 - 2950 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
+        - 703184","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 3375 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"4","amount":"110.0"}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:48 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:12 GMT
 - request:
-    method: post
-    uri: https://api.taxjar.com/v2/transactions/refunds
+    method: get
+    uri: https://api.taxjar.com/v2/transactions/refunds/R1234-old-transaction-REFUND
     body:
       encoding: UTF-8
-      string: '{"to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","transaction_id":"R851261413-REFUND","transaction_reference_id":"R851261413","transaction_date":"2022-02-17T22:49:47Z","amount":-110.0,"sales_tax":-9.77,"shipping":-100.0,"line_items":[{"unit_price":-10.0,"sales_tax":-0.89,"quantity":1,"product_tax_code":"TaxCode
-        - 99028","product_identifier":"SKU-1","id":0,"discount":-0.0,"description":"Product
-        #1 - 2950 - Master"}]}'
+      string: ''
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -222,68 +147,66 @@ http_interactions:
       - supergoodsolidustaxjar
       Connection:
       - close
-      Content-Type:
-      - application/json; charset=UTF-8
       Host:
       - api.taxjar.com
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '664'
+      - '687'
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:12 GMT
       X-Amzn-Requestid:
-      - 3bd35471-dcb5-4d78-a035-87f1b89bb1bb
+      - 24e34c14-fc3e-4f2e-b7d3-6c7604907682
       X-Amzn-Remapped-Content-Length:
-      - '664'
+      - '687'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d0xYhzf7b85eMUBB
+      - FwLFDRiUSyLgLUgKnHxB
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWZ9GK_oAMFvCg=
+      - Vb94qHBxIAMFvUA=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:12 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 4201bd1d1fc37ea7749b3bd1b64fce02.cloudfront.net (CloudFront)
+      - 1.1 ca66331b52971370c4e54619e8a952cc.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - CGK9xykS2I-tWJFluSGOfSUfOI3oEFDnS_nwZ1bR1kXKDcgw9t9Y4Q==
+      - DUvriz2W3tjmF_v0kO11tWc3C2VcvDFupBQTGIJcb2WzAmfAeY3Nmg==
     body:
       encoding: UTF-8
-      string: '{"refund":{"user_id":225397,"transaction_reference_id":"R851261413","transaction_id":"R851261413-REFUND","transaction_date":"2022-02-17T22:49:47.000Z","to_zip":"11430","to_street":"A
+      string: '{"refund":{"user_id":225397,"transaction_reference_id":"R1234-old-transaction","transaction_id":"R1234-old-transaction-REFUND","transaction_date":"2022-07-18T00:22:11.000Z","to_zip":"11430","to_street":"A
         Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"-100.0","sales_tax":"-9.77","provider":"api","line_items":[{"unit_price":"-10.0","sales_tax":"-0.89","quantity":1,"product_tax_code":"TaxCode
-        - 99028","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
-        #1 - 2950 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":null,"amount":"-110.0"}}'
+        - 703184","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 3375 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":null,"amount":"-110.0"}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:48 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:12 GMT
 - request:
     method: get
-    uri: https://api.taxjar.com/v2/transactions/orders/R851261413
+    uri: https://api.taxjar.com/v2/transactions/orders/R1234-old-transaction
     body:
       encoding: UTF-8
       string: ''
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -302,59 +225,59 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '642'
+      - '654'
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:13 GMT
       X-Amzn-Requestid:
-      - ec76ce84-ced5-42c7-b737-dd4452a67a24
+      - 3d30ecb2-90ec-421b-9c73-e330f3e402ad
       X-Amzn-Remapped-Content-Length:
-      - '642'
+      - '654'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d1sS544wX_dgbbYB
+      - FwLFDSpatglFoo8USKVB
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWaAFN0IAMFhrA=
+      - Vb94tEhHoAMFqPg=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:13 GMT
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 87136170926d082ce5ff23d5ad5be32c.cloudfront.net (CloudFront)
+      - 1.1 f7283f3fe2c258cf54f8b7d3dd272e0e.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - IhIanFsYj_8dvnRbPrW9uiXwjYCr3mIUIZS03Wv8riBO3KCVd9VVqA==
+      - X-AFOyHwMs6cvP33AfzZYU39qwd3xlu8g5Ovt_LEZC3YVtEDj4F0Tw==
     body:
       encoding: UTF-8
-      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R851261413","transaction_date":"2022-02-17T22:49:47.000Z","to_zip":"11430","to_street":"A
+      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R1234-old-transaction","transaction_date":"2022-07-18T00:22:11.000Z","to_zip":"11430","to_street":"A
         Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
-        - 99028","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
-        #1 - 2950 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
+        - 703184","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 3375 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"4","amount":"110.0"}}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:48 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:13 GMT
 - request:
     method: post
     uri: https://api.taxjar.com/v2/transactions/refunds
     body:
       encoding: UTF-8
       string: '{"to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
-        Different Road","transaction_id":"R851261413-REFUND","transaction_reference_id":"R851261413","transaction_date":"2022-02-17T22:49:47Z","amount":-110.0,"sales_tax":-9.77,"shipping":-100.0,"line_items":[{"unit_price":-10.0,"sales_tax":-0.89,"quantity":1,"product_tax_code":"TaxCode
-        - 99028","product_identifier":"SKU-1","id":0,"discount":-0.0,"description":"Product
-        #1 - 2950 - Master"}]}'
+        Different Road","transaction_id":"R1234-old-transaction-REFUND","transaction_reference_id":"R1234-old-transaction","transaction_date":"2022-07-18T00:31:12Z","amount":-110.0,"sales_tax":-9.77,"shipping":-100.0,"line_items":[{"unit_price":-10.0,"sales_tax":-0.89,"quantity":1,"product_tax_code":"TaxCode
+        - 703184","product_identifier":"SKU-1","id":0,"discount":-0.0,"description":"Product
+        #1 - 3375 - Master"}]}'
     headers:
       User-Agent:
-      - 'TaxJar/Ruby (Darwin agis.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5
-        21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64; ruby 2.7.4-p191;
-        OpenSSL 1.1.1k  25 Mar 2021) taxjar-ruby/3.0.2'
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.6.7-p197; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.3'
       Authorization:
       - Bearer <BEARER_TOKEN>
       X-Api-Version:
@@ -379,37 +302,37 @@ http_interactions:
       Connection:
       - close
       Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:13 GMT
       X-Amzn-Requestid:
-      - c2b69bea-021c-4421-a18e-d82a5e9c7e7f
+      - 912706ca-11e8-4b72-b074-9a314b7bfb80
       X-Amzn-Remapped-Content-Length:
       - '110'
       X-Amzn-Remapped-Connection:
       - keep-alive
       X-Request-Id:
-      - FtS0d2fCgvPxWpAtuzqD
+      - FwLFDT5Gn8sREPG0WpKB
       X-Api-Version:
       - '2020-08-07'
       X-Amz-Apigw-Id:
-      - NtWaCGZZIAMFWtw=
+      - Vb94wGEfoAMFnAA=
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Amzn-Remapped-Server:
       - Cowboy
       X-Amzn-Remapped-Date:
-      - Thu, 17 Feb 2022 22:49:48 GMT
+      - Mon, 18 Jul 2022 00:31:13 GMT
       X-Cache:
       - Error from cloudfront
       Via:
-      - 1.1 bf58b72d041cddee9bf926a00eeeb60a.cloudfront.net (CloudFront)
+      - 1.1 5abfab33f248090bb0f31ca137ce9464.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - YVR50-C1
+      - SEA73-P2
       X-Amz-Cf-Id:
-      - A_83-SzrqF8_8sKeohWF4tAKqC-ahGXTa7LLZn9eR3Kykuljf0VV8w==
+      - We9ElllXC9ML5HFQBTejvoJF_3ZfdKnRL43czMIQcVaCRIDmdQ8clQ==
     body:
       encoding: UTF-8
       string: '{"status":422,"error":"Unprocessable Entity","detail":"Provider tranx
         already imported for your user account"}'
     http_version:
-  recorded_at: Thu, 17 Feb 2022 22:49:48 GMT
+  recorded_at: Mon, 18 Jul 2022 00:31:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -143,19 +143,6 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
               end
             end
 
-            it "creates a new TaxJar order transaction" do
-              allow(dummy_client)
-                .to receive(:create_order)
-                .and_return(new_dummy_response)
-
-              perform_enqueued_jobs do
-                expect { subject }
-                  .to change { order.taxjar_order_transactions.count }
-                  .from(1)
-                  .to(2)
-              end
-            end
-
             context "when reporting is disabled" do
               let(:reporting_enabled) { false }
 

--- a/spec/super_good/solidus_taxjar/reporting_spec.rb
+++ b/spec/super_good/solidus_taxjar/reporting_spec.rb
@@ -4,12 +4,20 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
   let(:dummy_api) { instance_double ::SuperGood::SolidusTaxjar::Api }
   let(:order) { build :order, completed_at: 1.days.ago }
   let(:reporting) { described_class.new(api: dummy_api) }
-  let(:test_transaction_id) { "R1234-transaction" }
+  let(:test_order_transaction_id) { "R1234-transaction" }
+  let(:test_refund_transaction_id) { "R1234-old-transaction-REFUND" }
   let(:test_transaction_date) { Date.new(2022, 1, 1) }
   let(:taxjar_order_response_double) {
     double(
       "Taxjar::Order",
-      transaction_id: test_transaction_id,
+      transaction_id: test_order_transaction_id,
+      transaction_date: test_transaction_date
+    )
+  }
+  let(:taxjar_refund_response_double) {
+    double(
+      "Taxjar::Refund",
+      transaction_id: test_refund_transaction_id,
       transaction_date: test_transaction_date
     )
   }
@@ -17,11 +25,20 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
   describe "#refund_and_create_transaction" do
     subject { reporting.refund_and_create_new_transaction(order) }
 
-    let(:order) { create :order, completed_at: 1.days.ago }
+    let(:order) { create :order, completed_at: 1.days.ago, number: "R1234-old-transaction" }
+    let!(:order_transaction_to_refund) {
+      create(
+        :taxjar_order_transaction,
+        transaction_id: "R1234-old-transaction",
+        transaction_date: Date.new(2021, 1, 1),
+        order: order
+      )
+    }
 
     before do
       allow(dummy_api)
         .to receive(:create_refund_transaction_for)
+        .and_return(taxjar_refund_response_double)
 
       allow(dummy_api)
         .to receive(:create_transaction_for)
@@ -39,25 +56,52 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
         .with(order)
     end
 
+    it "creates a refund transaction record" do
+      expect { subject }
+        .to change { SuperGood::SolidusTaxjar::RefundTransaction.count }
+        .from(0)
+        .to(1)
+
+      expect(SuperGood::SolidusTaxjar::RefundTransaction.last).to have_attributes(
+        transaction_id: test_refund_transaction_id,
+        transaction_date: test_transaction_date,
+        order_transaction: order_transaction_to_refund
+      )
+    end
+
     it "creates and returns a transaction for the order" do
       expect(subject).to be_a(SuperGood::SolidusTaxjar::OrderTransaction)
       expect(subject.persisted?).to be_truthy
       expect(subject).to have_attributes(
-        transaction_id: test_transaction_id,
+        transaction_id: test_order_transaction_id,
         transaction_date: test_transaction_date
       )
     end
 
     context "when Taxjar cannot create a refund transaction", :vcr do
       let(:reporting) { described_class.new }
-      let(:order) { create(:completed_order_with_totals) }
+      let(:order) { create(:completed_order_with_totals, number: "R1234-old-transaction") }
       let!(:tax_rate) { create(:tax_rate, name: "Sales Tax") }
 
       # We ensure that TaxJar cannot create a refund transaction refunding it
       # *before* the test scenario.
       before do
-        SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
-        SuperGood::SolidusTaxjar.api.create_refund_transaction_for(order)
+        taxjar_api_client = ::SuperGood::SolidusTaxjar::Api.default_taxjar_client
+        begin
+          taxjar_api_client.show_order("R1234-old-transaction")
+        rescue Taxjar::Error::NotFound
+          taxjar_client.create_order(
+            ApiParams.transaction_params(order, "R1234-old-transaction")
+          )
+        end
+
+        begin
+          taxjar_api_client.show_refund("R1234-old-transaction-REFUND")
+        rescue Taxjar::Error::NotFound
+          taxjar_client.create_refund(
+            ApiParams.refund_transaction_params(order, order_transaction_to_refund)
+          )
+        end
       end
 
       it "raises an error" do
@@ -85,7 +129,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
 
     context "the order has an existing transaction" do
       before do
-        create :taxjar_order_transaction, transaction_id: test_transaction_id, transaction_date: test_transaction_date
+        create :taxjar_order_transaction, transaction_id: test_order_transaction_id, transaction_date: test_transaction_date
       end
 
       it "returns the existing taxjar order transaction record" do
@@ -102,7 +146,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
         expect(subject).to be_a(SuperGood::SolidusTaxjar::OrderTransaction)
         expect(subject.persisted?).to be_truthy
         expect(subject).to have_attributes(
-          transaction_id: test_transaction_id,
+          transaction_id: test_order_transaction_id,
           transaction_date: test_transaction_date
         )
       end
@@ -129,7 +173,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
           expect(subject).to be_a(SuperGood::SolidusTaxjar::OrderTransaction)
           expect(subject.persisted?).to be_truthy
           expect(subject).to have_attributes(
-            transaction_id: test_transaction_id,
+            transaction_id: test_order_transaction_id,
             transaction_date: test_transaction_date
           )
         end

--- a/spec/super_good/solidus_taxjar/reporting_spec.rb
+++ b/spec/super_good/solidus_taxjar/reporting_spec.rb
@@ -19,25 +19,27 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
 
     let(:order) { create :order, completed_at: 1.days.ago }
 
-    it "refunds the transaction and creates a new one in TaxJar" do
-      expect(dummy_api)
-        .to receive(:create_refund_transaction_for)
-        .with(order)
-      expect(dummy_api)
-        .to receive(:create_transaction_for)
-        .with(order)
-
-      subject
-    end
-
-    it "creates a transaction for the order" do
+    before do
       allow(dummy_api)
         .to receive(:create_refund_transaction_for)
 
       allow(dummy_api)
         .to receive(:create_transaction_for)
         .and_return(taxjar_order_response_double)
+    end
 
+    it "refunds the transaction and creates a new one in TaxJar" do
+      subject
+
+      expect(dummy_api)
+        .to have_received(:create_refund_transaction_for)
+        .with(order)
+      expect(dummy_api)
+        .to have_received(:create_transaction_for)
+        .with(order)
+    end
+
+    it "creates and returns a transaction for the order" do
       expect(subject).to be_a(SuperGood::SolidusTaxjar::OrderTransaction)
       expect(subject.persisted?).to be_truthy
       expect(subject).to have_attributes(


### PR DESCRIPTION
What is the goal of this PR?
---

A model existed for refund transactions but was not being created when a refund was reported.

This adds the extra step of creating a refund model after a refund is reported.

How do you manually test these changes? (if applicable)
---

1. Refund an order
    * [x] Ensure a Refund transaction model is created in the database with the appropriate order transaction attached.

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
