### PR TITLE
[176] Handle partial refund failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - [#181](https://github.com/SuperGoodSoft/solidus_taxjar/pull/181) Take all non-tax adjustment types into account when calculating a line item's discount
 - [#182](https://github.com/SuperGoodSoft/solidus_taxjar/pull/182) Automatically create default Tax Rate
 - [#176](https://github.com/SuperGoodSoft/solidus_taxjar/pull/176) Create refund transaction database models when reporting refunds.
-
+- [#192](https://github.com/SuperGoodSoft/solidus_taxjar/pull/192) Handle failures that occur in the middle of refunding a transaction.
 ## Upgrading Instructions
 
 * If you had previously configured a `Spree::TaxRate` with the name "Sales Tax", it can be deleted after upgrading, as a new `Spree::TaxRate` with the name "Solidus TaxJar Rate" will automatically be created. Alternatively, you can rename your existing `Spree::TaxRate` from "Sales Tax" to "Solidus TaxJar Rate". [#182](https://github.com/SuperGoodSoft/solidus_taxjar/pull/182)

--- a/lib/super_good/solidus_taxjar/reporting.rb
+++ b/lib/super_good/solidus_taxjar/reporting.rb
@@ -6,12 +6,14 @@ module SuperGood
       end
 
       def refund_and_create_new_transaction(order)
-        transaction_response = @api.create_refund_transaction_for(order)
         latest_order_transaction = OrderTransaction.latest_for(order)
-        latest_order_transaction.create_refund_transaction!(
-          transaction_id: transaction_response.transaction_id,
-          transaction_date: transaction_response.transaction_date
-        )
+        unless latest_order_transaction.refund_transaction
+          transaction_response = @api.create_refund_transaction_for(order)
+          latest_order_transaction.create_refund_transaction!(
+            transaction_id: transaction_response.transaction_id,
+            transaction_date: transaction_response.transaction_date
+          )
+        end
         if transaction_response = @api.create_transaction_for(order)
           order.taxjar_order_transactions.create!(
             transaction_id: transaction_response.transaction_id,

--- a/lib/super_good/solidus_taxjar/testing_support/factories/refund_transaction_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/refund_transaction_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :taxjar_refund_transaction, class: "SuperGood::SolidusTaxjar::RefundTransaction" do
+    order_transaction { create :taxjar_order_transaction }
+    sequence(:transaction_id) { |n| "RefundTransaction-#{n}" }
+    transaction_date { Date.current }
+  end
+end

--- a/spec/super_good/solidus_taxjar/reporting_spec.rb
+++ b/spec/super_good/solidus_taxjar/reporting_spec.rb
@@ -122,6 +122,30 @@ RSpec.describe SuperGood::SolidusTaxjar::Reporting do
         end
       end
     end
+
+    context "when a partially completed refund exists in the database" do
+      before do
+        create :taxjar_refund_transaction, order_transaction: order_transaction_to_refund
+      end
+
+      it "skips creating the refund transaction and model" do
+        expect { subject }
+          .not_to change { SuperGood::SolidusTaxjar::RefundTransaction.count }
+
+        expect(dummy_api)
+          .not_to have_received(:create_refund_transaction_for)
+      end
+
+      it "creates a new order transaction" do
+        expect { subject }
+          .to change { SuperGood::SolidusTaxjar::OrderTransaction.count }
+          .from(1)
+          .to(2)
+
+        expect(dummy_api)
+          .to have_received(:create_transaction_for)
+      end
+    end
   end
 
   describe "#show_or_create_transaction" do


### PR DESCRIPTION
What is the goal of this PR?
---

Reporting a refund to TaxJar consists of two steps
1. Refunding the entire order
2. Reporting a new partial transaction.

We want to ensure that if step 1 succeeds but step 2 fails, that the. `refund_and_create_new_transaction` method can be called again successfully.

How do you manually test these changes? (if applicable)
---

1. Mimic a partial refund failure (using request hacks? Commented out code?
2. Try to re-report the refund transaction (re-queue the job?)
    * [x] Ensure the refund suceeds!

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog