### PR TITLE
Update extension for new Omnes event 🚌 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#193](https://github.com/SuperGoodSoft/solidus_taxjar/pull/193) Bump version requirement for `solidus_support` to ">= 0.9.0", and as a result drop support for Rails 5.2.
 - [#190](https://github.com/SuperGoodSoft/solidus_taxjar/pull/190) Add transaction sync batch show page
 - [#188](https://github.com/SuperGoodSoft/solidus_taxjar/pull/188) Show transaction sync batches in user interface
 - [#185](https://github.com/SuperGoodSoft/solidus_taxjar/pull/185) Backfill transactions in batches

--- a/app/overrides/super_good/solidus_taxjar/spree/order_updater/fire_recalculated_event.rb
+++ b/app/overrides/super_good/solidus_taxjar/spree/order_updater/fire_recalculated_event.rb
@@ -4,6 +4,10 @@ module SuperGood
   module SolidusTaxjar
     module Spree
       module OrderUpdater
+        # Responsible for introducing the `order_recalculated` event for older
+        # versions of Solidus (from 2.9 up until but not including 2.11) which
+        # do not have this event. TaxJar transaction reporting relies on this
+        # event firing when an order is recalculated.
         module FireRecalculatedEvent
           def persist_totals
             ::Spree::Event.fire 'order_recalculated', order: order

--- a/app/overrides/super_good/solidus_taxjar/spree/shipment/fire_shipment_shipped_event.rb
+++ b/app/overrides/super_good/solidus_taxjar/spree/shipment/fire_shipment_shipped_event.rb
@@ -6,7 +6,11 @@ module SuperGood
       module Shipment
         module FireShipmentShippedEvent
           def after_ship
-            ::Spree::Event.fire 'shipment_shipped', shipment: self
+            SolidusSupport::LegacyEventCompat::Bus.publish(
+              :shipment_shipped,
+              shipment: self
+            )
+
             super
           end
 

--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -3,6 +3,7 @@ module SuperGood
     module Spree
       module ReportingSubscriber
         include ::Spree::Event::Subscriber
+        include SolidusSupport::LegacyEventCompat::Subscriber
 
         if ::Spree::Event.method_defined?(:register)
           ::Spree::Event.register("shipment_shipped")

--- a/lib/generators/super_good/solidus_taxjar/install/install_generator.rb
+++ b/lib/generators/super_good/solidus_taxjar/install/install_generator.rb
@@ -15,6 +15,22 @@ module SuperGood
           INIT
         end
 
+        def create_omes_initializer_file
+          return unless Gem::Requirement.new('>= 3.2.0.alpha')
+            .satisfied_by?(::Spree.solidus_gem_version)
+
+          omnes_initializer_path = "config/initializers/omnes.rb"
+
+          create_file(omnes_initializer_path) unless File.exists?(omnes_initializer_path )
+          append_to_file(omnes_initializer_path, <<~INIT)
+            Rails.application.config.to_prepare do
+              ::Spree::Bus.register(:shipment_shipped)
+              SuperGood::SolidusTaxjar::Spree::ReportingSubscriber.omnes_subscriber.subscribe_to(Spree::Bus)
+            end
+          INIT
+
+        end
+
         def add_migrations
           run 'bin/rails railties:install:migrations FROM=super_good_solidus_taxjar'
         end

--- a/lib/super_good/engine.rb
+++ b/lib/super_good/engine.rb
@@ -5,6 +5,9 @@ module SuperGoodSolidusTaxjar
     isolate_namespace Spree
     engine_name 'super_good_solidus_taxjar'
 
+    # Solidus versions prior to 2.11.0 do not support auto-loading of subscribers
+    # so we need to manually register the reporting subscriber with the event
+    # bus.
     if Spree.solidus_gem_version < Gem::Version.new('2.11.0')
       require root.join('app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber')
       SuperGood::SolidusTaxjar::Spree::ReportingSubscriber.subscribe!

--- a/spec/models/spree/order_updater_spec.rb
+++ b/spec/models/spree/order_updater_spec.rb
@@ -1,12 +1,45 @@
 RSpec.describe Spree::OrderUpdater do
   describe '#update' do
+    subject { described_class.new(order).update }
+
+    let(:order) { create(:order) }
+
+    module TestSubscriber
+      include Spree::Event::Subscriber
+      include SolidusSupport::LegacyEventCompat::Subscriber
+
+      event_action :order_recalculated
+
+      def order_recalculated(_event)
+      end
+    end
+
+    if SolidusSupport::LegacyEventCompat.using_legacy?
+      let(:event_type_class) { ActiveSupport::Notifications::Event }
+
+      before do
+        if TestSubscriber.respond_to?(:subscribe!)
+          TestSubscriber.subscribe!
+        else
+          TestSubscriber.activate
+        end
+      end
+    else
+      let(:event_type_class) { Omnes::UnstructuredEvent }
+
+      before { TestSubscriber.omnes_subscriber.subscribe_to(Spree::Bus) }
+    end
+
     it 'fires the order_recalculated event exactly once' do
-      stub_const('Spree::Event', class_spy(Spree::Event))
-      order = create(:order)
+      allow(TestSubscriber).to receive(:order_recalculated)
 
-      described_class.new(order).update
+      subject
 
-      expect(Spree::Event).to have_received(:fire).with('order_recalculated', order: order).once
+      expect(TestSubscriber).to have_received(:order_recalculated)
+        .with(instance_of(event_type_class))
+        .once do |event|
+          expect(event.payload[:order]).to eq(order)
+        end
     end
   end
 end

--- a/spec/models/spree/shipment_spec.rb
+++ b/spec/models/spree/shipment_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe Spree::Shipment do
     let(:order) { create :order_with_line_items }
 
     it 'fires the shipment_shipped event exactly once' do
-      stub_const('Spree::Event', class_spy(Spree::Event))
-
-      expect(Spree::Event).to receive(:fire).with('shipment_shipped', shipment: shipment).once
+      expect(SolidusSupport::LegacyEventCompat::Bus)
+        .to receive(:publish)
+        .with(
+          :shipment_shipped,
+          shipment: shipment
+        )
+        .once
 
       subject
     end

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
   let(:reporting_enabled) { true }
 
   describe "order_recalculated is fired" do
-    subject { ::Spree::Event.fire "order_recalculated", order: order }
+    subject do
+      SolidusSupport::LegacyEventCompat::Bus.publish(
+        :order_recalculated,
+        order: order
+      )
+    end
 
     context "when the order is completed" do
       context "when the order has not been shipped" do
@@ -197,7 +202,12 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
   end
 
   describe "shipment_shipped is fired" do
-    subject { Spree::Event.fire "shipment_shipped", shipment: shipment }
+    subject do
+      SolidusSupport::LegacyEventCompat::Bus.publish(
+        :shipment_shipped,
+        shipment: shipment
+      )
+    end
 
     before do
       # Ignore other events that may be triggered by factories here.

--- a/super_good-solidus_taxjar.gemspec
+++ b/super_good-solidus_taxjar.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "solidus_core", ">= 2.4.0"
-  spec.add_dependency "solidus_support"
+  spec.add_dependency "solidus_support", ">= 0.9.0"
   spec.add_dependency "taxjar-ruby"
 
   spec.add_development_dependency "solidus_dev_support"


### PR DESCRIPTION
What is the goal of this PR?
---
Get tests passing against Solidus `master`.
Update the way we use the Solidus event bus to be forwards compatible with the new Omens bus implementation that is now default in Solidus "=> 3.2.0.alpha" - https://github.com/solidusio/solidus/pull/4342

Additional information on updating to the new event bus implementation - https://github.com/solidusio/solidus/discussions/4380

How do you manually test these changes?
---

1. Test the reporting features against Solidus `master`
    * [ ] Create and ship an order and verify it is created as a transaction on TaxJar
    * [ ] Update an order (cancel an item) and confirm the original transaction is refunded on TaxJar and a replacement is created
1. Run the same tests against Solidus 3.0

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog