### PR TITLE
[150] Asynchronously process transaction backfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#192](https://github.com/SuperGoodSoft/solidus_taxjar/pull/192) Handle failures that occur in the middle of refunding a transaction.
 - [#194](https://github.com/SuperGoodSoft/solidus_taxjar/pull/194) Move the transaction backfill button to it's own unique page
 - [#198](https://github.com/SuperGoodSoft/solidus_taxjar/pull/198) Don't create zero dollar transactions when an order is fully refunded.
+- [#195](https://github.com/SuperGoodSoft/solidus_taxjar/pull/195) Run transaction backfills asynchronously
 
 ## Upgrading Instructions
 

--- a/app/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SuperGood
+  module SolidusTaxjar
+    class BackfillTransactionSyncBatchJob < ApplicationJob
+      queue_as { SuperGood::SolidusTaxjar.job_queue }
+
+      def perform(transaction_sync_batch)
+        ::Spree::Order.complete.where(shipment_state: 'shipped').find_each do |order|
+          next if order.taxjar_order_transactions.any?
+          transaction_sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
+            transaction_sync_batch: transaction_sync_batch,
+            order: order
+          )
+          begin
+            order_transaction = SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
+            transaction_sync_log.update!(order_transaction: order_transaction, status: :success)
+          rescue Taxjar::Error => exception
+            transaction_sync_log.update!(status: :error, error_message: exception.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_good/solidus_taxjar/backfill_transactions.rb
+++ b/lib/super_good/solidus_taxjar/backfill_transactions.rb
@@ -1,10 +1,6 @@
 module SuperGood
   module SolidusTaxjar
     class BackfillTransactions
-      def initialize(api: SuperGood::SolidusTaxjar.api)
-        @api = api
-      end
-
       def call
         transaction_sync_batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.create!
 
@@ -24,10 +20,6 @@ module SuperGood
 
         transaction_sync_batch
       end
-
-      private
-
-      attr_reader :api
     end
   end
 end

--- a/lib/super_good/solidus_taxjar/backfill_transactions.rb
+++ b/lib/super_good/solidus_taxjar/backfill_transactions.rb
@@ -3,21 +3,7 @@ module SuperGood
     class BackfillTransactions
       def call
         transaction_sync_batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.create!
-
-        ::Spree::Order.complete.where(shipment_state: 'shipped').find_each do |order|
-          next if order.taxjar_order_transactions.any?
-          transaction_sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
-            transaction_sync_batch: transaction_sync_batch,
-            order: order
-          )
-          begin
-            order_transaction = SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
-            transaction_sync_log.update!(order_transaction: order_transaction, status: :success)
-          rescue Taxjar::Error => exception
-            transaction_sync_log.update!(status: :error, error_message: exception.message)
-          end
-        end
-
+        SuperGood::SolidusTaxjar::BackfillTransactionSyncBatchJob.perform_later(transaction_sync_batch)
         transaction_sync_batch
       end
     end

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
           click_on "Backfill Transactions"
         end
       end
-      expect(page).to have_content "Transaction Sync Batch 1"
+      expect(page).to have_content /Transaction Sync Batch \d/
       within "#transaction_sync_batch_logs" do
         expect(page).to have_content order.number
         within "tbody td:nth-child(4)" do

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -23,7 +23,9 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
       expect(page).to have_content("TaxJar Backfill")
       click_on "TaxJar Backfill"
       within ".header-actions" do
-        click_on "Backfill Transactions"
+        perform_enqueued_jobs do
+          click_on "Backfill Transactions"
+        end
       end
       expect(page).to have_content "Transaction Sync Batch 1"
       within "#transaction_sync_batch_logs" do
@@ -34,7 +36,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
       end
     end
   end
-  
+
   feature "user has started a transaction backfill" do
     let!(:transaction_sync_batch) { create :transaction_sync_batch }
     let!(:second_transaction_sync_batch) { create :transaction_sync_batch, :with_logs }
@@ -94,7 +96,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
           within "td:nth-child(2)" do
             expect(page).to have_content(processing_transaction_sync_log.order.number)
           end
-          
+
           within "td:nth-child(3)" do
             expect(page).to have_content("-")
           end

--- a/spec/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job_spec.rb
+++ b/spec/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactionSyncBatchJob do
+  describe "#perform" do
+    subject { described_class.new.perform(batch) }
+
+    let!(:shipped_order) { create :shipped_order }
+    let(:reporting_mock) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
+    let(:test_transaction_id) { "R1234-transaction" }
+    let(:batch) { create :transaction_sync_batch }
+
+    around do |example|
+      ::SuperGood::SolidusTaxjar.test_mode = true
+      example.run
+      ::SuperGood::SolidusTaxjar.test_mode = false
+    end
+
+    before do
+      reported_order = create :shipped_order
+      create(:taxjar_order_transaction, order: reported_order)
+      create :order_ready_to_ship
+
+      unreported_transaction = build(:taxjar_order_transaction, order: shipped_order, transaction_id: test_transaction_id)
+
+      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(reporting_mock)
+      allow(reporting_mock).to receive(:show_or_create_transaction) do
+        unreported_transaction.save!
+        unreported_transaction
+      end
+    end
+
+    it "reports the transaction to TaxJar" do
+      subject
+
+      expect(reporting_mock).to have_received(:show_or_create_transaction).with(shipped_order)
+    end
+
+    it "creates a log of each synced order in the database" do
+      subject
+      expect(batch.transaction_sync_logs.count).to eq(1)
+      expect(batch.transaction_sync_logs.last.order).to eq(shipped_order)
+    end
+
+    it "records the associated order, taxjar transaction, and status on each log" do
+      subject
+      sync_log = batch.transaction_sync_logs.last
+
+      expect(sync_log).to have_attributes(
+        order: shipped_order,
+        status: "success"
+      )
+      expect(sync_log.order_transaction).not_to be_nil
+    end
+
+    context "when the transaction cannot be created on TaxJar" do
+      before do
+        allow(reporting_mock)
+          .to receive(:show_or_create_transaction)
+          .and_raise(Taxjar::Error.new("api down"))
+      end
+
+      it "records a failure status in the log" do
+        subject
+        sync_log = batch.transaction_sync_logs.last
+
+        expect(sync_log).to have_attributes(
+          order: shipped_order,
+          status: "error",
+          error_message: /api down/
+        )
+
+        expect(sync_log.order_transaction).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/spree/admin/transaction_sync_batches_request_spec.rb
+++ b/spec/requests/spree/admin/transaction_sync_batches_request_spec.rb
@@ -10,14 +10,20 @@ RSpec.describe Spree::Admin::TransactionSyncBatchesController, :vcr, :type => :r
     example.run
     ActionController::Base.allow_forgery_protection = original
   end
-  
+
   describe "#create" do
     subject { post spree.admin_transaction_sync_batches_path }
 
     let!(:order) { create(:shipped_order) }
 
     it "creates a batch with a log for the order" do
-      expect { subject }.to change { SuperGood::SolidusTaxjar::TransactionSyncBatch.count }.from(0).to(1)
+      perform_enqueued_jobs do
+        expect { subject }
+          .to change { SuperGood::SolidusTaxjar::TransactionSyncBatch.count }
+          .from(0)
+          .to(1)
+      end
+
       batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.last
       expect(batch.transaction_sync_logs.last.order).to eq order
     end

--- a/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
+++ b/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactions do
-  describe ".call" do
+  describe "#call" do
     subject { described_class.new(api: api_spy).call }
 
     let!(:shipped_order) { create :shipped_order }

--- a/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
+++ b/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
@@ -2,11 +2,10 @@ require "spec_helper"
 
 RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactions do
   describe "#call" do
-    subject { described_class.new(api: api_spy).call }
+    subject { described_class.new.call }
 
     let!(:shipped_order) { create :shipped_order }
     let(:reporting_mock) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
-    let(:api_spy) { instance_spy(::SuperGood::SolidusTaxjar::Api) }
     let(:test_transaction_id) { "R1234-transaction" }
 
     around do |example|

--- a/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
+++ b/spec/super_good/solidus_taxjar/backfill_transactions_spec.rb
@@ -4,78 +4,14 @@ RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactions do
   describe "#call" do
     subject { described_class.new.call }
 
-    let!(:shipped_order) { create :shipped_order }
-    let(:reporting_mock) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
-    let(:test_transaction_id) { "R1234-transaction" }
-
-    around do |example|
-      ::SuperGood::SolidusTaxjar.test_mode = true
-      example.run
-      ::SuperGood::SolidusTaxjar.test_mode = false
-    end
-
-    before do
-      reported_order = create :shipped_order
-      create(:taxjar_order_transaction, order: reported_order)
-      create :order_ready_to_ship
-
-      unreported_transaction = build(:taxjar_order_transaction, order: shipped_order, transaction_id: test_transaction_id)
-
-      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(reporting_mock)
-      allow(reporting_mock).to receive(:show_or_create_transaction) do
-        unreported_transaction.save!
-        unreported_transaction
-      end
-    end
-
-    it "reports the transaction to TaxJar" do
-      subject
-
-      expect(reporting_mock).to have_received(:show_or_create_transaction).with(shipped_order)
-    end
-
-    it "returns the associated transaction sync batch" do
+    it "returns a new transaction sync batch" do
       expect(subject).to be_a(SuperGood::SolidusTaxjar::TransactionSyncBatch)
     end
 
-    it "creates a log of each synced order in the database" do
-      expect { subject }.to change { SuperGood::SolidusTaxjar::TransactionSyncBatch.count }
-        .from(0).to(1)
-      transaction_sync_batch = SuperGood::SolidusTaxjar::TransactionSyncBatch.last
-      expect(transaction_sync_batch.transaction_sync_logs.count).to eq(1)
-      expect(transaction_sync_batch.transaction_sync_logs.last.order).to eq(shipped_order)
-    end
-
-    it "records the associated order, taxjar transaction, and status on each log" do
-      subject
-      sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.last
-
-      expect(sync_log).to have_attributes(
-        order: shipped_order,
-        status: "success"
-      )
-      expect(sync_log.order_transaction).not_to be_nil
-    end
-
-    context "when the transaction cannot be created on TaxJar" do
-      before do
-        allow(reporting_mock)
-          .to receive(:show_or_create_transaction)
-          .and_raise(Taxjar::Error.new("api down"))
-      end
-
-      it "records a failure status in the log" do
-        subject
-        sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.last
-
-        expect(sync_log).to have_attributes(
-          order: shipped_order,
-          status: "error",
-          error_message: /api down/
-        )
-
-        expect(sync_log.order_transaction).to be_nil
-      end
+    it "queues a job to backfill the transactions in the batch" do
+      expect { subject }
+        .to have_enqueued_job(SuperGood::SolidusTaxjar::BackfillTransactionSyncBatchJob)
+        .with(kind_of(SuperGood::SolidusTaxjar::TransactionSyncBatch))
     end
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

Transaction backfills have the potential to encompass a large number of orders, so we should execute them asychronously, and direct the user to the in progress batch display page.

How do you manually test these changes? (if applicable)
---

* [x] Smoke test backfilling transactions

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog