### PR TITLE
[176] Don't create new transactions for full refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [#176](https://github.com/SuperGoodSoft/solidus_taxjar/pull/176) Create refund transaction database models when reporting refunds.
 - [#192](https://github.com/SuperGoodSoft/solidus_taxjar/pull/192) Handle failures that occur in the middle of refunding a transaction.
 - [#194](https://github.com/SuperGoodSoft/solidus_taxjar/pull/194) Move the transaction backfill button to it's own unique page
+- [#198](https://github.com/SuperGoodSoft/solidus_taxjar/pull/198) Don't create zero dollar transactions when an order is fully refunded.
 
 ## Upgrading Instructions
 

--- a/lib/super_good/solidus_taxjar/reporting.rb
+++ b/lib/super_good/solidus_taxjar/reporting.rb
@@ -14,6 +14,9 @@ module SuperGood
             transaction_date: transaction_response.transaction_date
           )
         end
+
+        return if order.total.zero?
+
         if transaction_response = @api.create_transaction_for(order)
           order.taxjar_order_transactions.create!(
             transaction_id: transaction_response.transaction_id,


### PR DESCRIPTION
What is the goal of this PR?
---

If the entire amount of an order is refunded, and the new order total
is zero, we should not create a subsequent order transaction for zero
dollars after refunding.

We still want to allow some intentionally discounted zero dollar orders
be reported, as the item total affects the nexus and tax
calculations for certain states.

How do you manually test these changes? (if applicable)
---

1. Refund the entire amount of an order with free shipping 
    * [x] Ensure a refund transaction is created
    * [x] Ensure a order transaction is **not** created

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog