### PR TITLE
[150] Render transaction sync log error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [#195](https://github.com/SuperGoodSoft/solidus_taxjar/pull/195) Run transaction backfills asynchronously
 - [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/200) Expand solidus gem into dependencies to support Solidus 3.2+
 - [#183](https://github.com/SuperGoodSoft/solidus_taxjar/pull/183) Add ability to fetch tax codes from TaxJar and assign to tax categories in admin
+- [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/199) Render error message when backfilling transactions fails
 
 ## Upgrading Instructions
 

--- a/app/views/spree/admin/transaction_sync_batches/show.html.erb
+++ b/app/views/spree/admin/transaction_sync_batches/show.html.erb
@@ -11,6 +11,7 @@
       <th>Order</th>
       <th>TaxJar Transaction ID</th>
       <th>Status</th>
+      <th>Error Message</th>
       <th>Created at</th>
       <th>Updated at</th>
     </tr>
@@ -22,6 +23,7 @@
         <td><%= link_to log.order.number, spree.edit_admin_order_path(log.order) %></td>
         <td><%= log.order_transaction&.transaction_id || "-" %></td>
         <td><%= log.status.capitalize %></td>
+        <td style="white-space: pre-wrap; width: 150px;"><%= log.error_message %></td>
         <td><%= log.created_at %></td>
         <td><%= log.updated_at %></td>
       </tr>

--- a/spec/requests/spree/admin/transaction_sync_batches_request_spec.rb
+++ b/spec/requests/spree/admin/transaction_sync_batches_request_spec.rb
@@ -28,4 +28,17 @@ RSpec.describe Spree::Admin::TransactionSyncBatchesController, :vcr, :type => :r
       expect(batch.transaction_sync_logs.last.order).to eq order
     end
   end
+
+  describe "#show" do
+    subject { get spree.admin_transaction_sync_batch_path(transaction_sync_batch) }
+
+    let(:error_message) { "Uh Oh" }
+    let(:transaction_sync_batch) { create :transaction_sync_batch, transaction_sync_logs: [transaction_sync_log] }
+    let(:transaction_sync_log) { build :transaction_sync_log, error_message: error_message }
+
+    it "renders the transaction sync log error message" do
+      subject
+      expect(response.body).to include(error_message)
+    end
+  end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

When an order fails to sync in a transaction backfill, we should render the reason in the UI.

How do you manually test these changes? (if applicable)
---

1. Backfill a transaction and have it fail
    * [x] Ensure that the error message is displayed in the UI

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog


Screenshots
---
<img width="1092" alt="Screen Shot 2022-09-07 at 14 31 07PDT" src="https://user-images.githubusercontent.com/8933450/188985993-ff13c818-6006-401c-ae2f-42404747dd85.png">

