### PR TITLE
Expand solidus meta gem into dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [#194](https://github.com/SuperGoodSoft/solidus_taxjar/pull/194) Move the transaction backfill button to it's own unique page
 - [#198](https://github.com/SuperGoodSoft/solidus_taxjar/pull/198) Don't create zero dollar transactions when an order is fully refunded.
 - [#195](https://github.com/SuperGoodSoft/solidus_taxjar/pull/195) Run transaction backfills asynchronously
+- [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/200) Expand solidus gem into dependencies to support Solidus 3.2+
 
 ## Upgrading Instructions
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,17 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 branch = ENV.fetch("SOLIDUS_BRANCH", "v3.1")
+git "https://github.com/solidusio/solidus.git", branch: branch do
+  gem "solidus_core"
+  gem "solidus_backend"
+  gem "solidus_frontend"
+  gem "solidus_api"
+  gem "solidus_sample"
+end
 
-gem "solidus", github: "solidusio/solidus", branch: branch
-
+gem "rails"
 # Provides basic authentication functionality for testing parts of your engine
 gem "solidus_auth_devise"
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,14 @@ branch = ENV.fetch("SOLIDUS_BRANCH", "v3.1")
 git "https://github.com/solidusio/solidus.git", branch: branch do
   gem "solidus_core"
   gem "solidus_backend"
-  gem "solidus_frontend"
   gem "solidus_api"
   gem "solidus_sample"
+end
+
+if (branch == 'master') || (branch >= 'v3.2')
+  gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: branch
+else
+  gem "solidus_frontend", github: "solidusio/solidus", branch: branch
 end
 
 gem "rails"

--- a/lib/super_good/solidus_taxjar/testing_support/factories/transaction_sync_log_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/transaction_sync_log_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :transaction_sync_log, class: "SuperGood::SolidusTaxjar::TransactionSyncLog" do
-    order
+    association :order, strategy: :create
 
     trait :success do
       status { "success" }


### PR DESCRIPTION
What is the goal of this PR?
---

Now that Solidus `master` doesn't include `solidus_frontend` by default
the `common:test_app` rake task modifies extension Gemfile to expand the
meta gem into it's parts. This change commits the diff that we would
otherwise get when running `bin/rake` without an existing dummy app.

We also need to require "rails" again to make the specs pass, else we get
a zeitwerk loading error.

Merge Checklist
---

- [ ] Run the manual tests
- [x] Update the changelog
