### PR TITLE
[186] Add transaction sync status to orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#183](https://github.com/SuperGoodSoft/solidus_taxjar/pull/183) Add ability to fetch tax codes from TaxJar and assign to tax categories in admin
 - [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/200) Render error message when backfilling transactions fails
 - [#203](https://github.com/SuperGoodSoft/solidus_taxjar/pull/203) Remove outdated backfill button
+- [#202](https://github.com/SuperGoodSoft/solidus_taxjar/pull/202) Add TaxJar transaction sync status to order show page
 
 ## Upgrading Instructions
 

--- a/app/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job.rb
@@ -8,16 +8,7 @@ module SuperGood
       def perform(transaction_sync_batch)
         ::Spree::Order.complete.where(shipment_state: 'shipped').find_each do |order|
           next if order.taxjar_order_transactions.any?
-          transaction_sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
-            transaction_sync_batch: transaction_sync_batch,
-            order: order
-          )
-          begin
-            order_transaction = SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
-            transaction_sync_log.update!(order_transaction: order_transaction, status: :success)
-          rescue Taxjar::Error => exception
-            transaction_sync_log.update!(status: :error, error_message: exception.message)
-          end
+          SuperGood::SolidusTaxjar::ReportTransactionJob.perform_later(order, transaction_sync_batch)
         end
       end
     end

--- a/app/jobs/super_good/solidus_taxjar/report_transaction_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/report_transaction_job.rb
@@ -5,8 +5,9 @@ module SuperGood
     class ReportTransactionJob < ApplicationJob
       queue_as { SuperGood::SolidusTaxjar.job_queue }
 
-      def perform(order)
+      def perform(order, transaction_sync_batch = nil)
         transaction_sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
+          transaction_sync_batch: transaction_sync_batch,
           order: order
         )
         begin

--- a/app/jobs/super_good/solidus_taxjar/report_transaction_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/report_transaction_job.rb
@@ -6,7 +6,15 @@ module SuperGood
       queue_as { SuperGood::SolidusTaxjar.job_queue }
 
       def perform(order)
-        SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
+        transaction_sync_log = SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
+          order: order
+        )
+        begin
+          order_transaction = SuperGood::SolidusTaxjar.reporting.show_or_create_transaction(order)
+          transaction_sync_log.update!(order_transaction: order_transaction, status: :success)
+        rescue Taxjar::Error => exception
+          transaction_sync_log.update!(status: :error, error_message: exception.message)
+        end
       end
     end
   end

--- a/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
+++ b/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
@@ -1,5 +1,5 @@
 class SuperGood::SolidusTaxjar::TransactionSyncLog < ApplicationRecord
-  belongs_to :transaction_sync_batch
+  belongs_to :transaction_sync_batch, optional: true
   belongs_to :order, class_name: "Spree::Order"
   belongs_to :order_transaction, optional: true
 

--- a/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
@@ -1,0 +1,8 @@
+
+<!-- insert_bottom "[id='order_tab_summary'] > .additional-info" -->
+
+<% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
+  <dt>Reported to TaxJar at:</dt>
+  <% last_sync_date = @order.taxjar_transaction_sync_logs.order(:created_at).last&.created_at %>
+  <dd> <%= last_sync_date ? pretty_time(last_sync_date) : "-" %></dd>
+<% end

--- a/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
@@ -1,8 +1,30 @@
 
 <!-- insert_bottom "[id='order_tab_summary'] > .additional-info" -->
 
+<% content_for :head do %>
+  <style>
+    .pill-success {
+      background: #c8d8e8;
+    }
+  </style>
+<% end %>
+
 <% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
+  <% last_sync_log = @order.taxjar_transaction_sync_logs.order(:created_at).last %>
   <dt>Reported to TaxJar at:</dt>
-  <% last_sync_date = @order.taxjar_transaction_sync_logs.order(:created_at).last&.created_at %>
-  <dd> <%= last_sync_date ? pretty_time(last_sync_date) : "-" %></dd>
+  <dd> <%= last_sync_log ? pretty_time(last_sync_log.created_at) : "-" %></dd>
+  <dt>TaxJar Sync: </dt>
+  <dd>
+    <% last_sync_log_status = if last_sync_log
+        last_sync_log.status
+      else
+        SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled ?
+          "pending" :
+          "disabled"
+      end
+    %>
+    <span class="pill pill-<%= last_sync_log_status %>">
+      <%= last_sync_log_status.capitalize %>
+    </span>
+  </dd>
 <% end

--- a/app/overrides/super_good/solidus_taxjar/spree/order_override.rb
+++ b/app/overrides/super_good/solidus_taxjar/spree/order_override.rb
@@ -7,6 +7,10 @@ module SuperGood
             class_name: "SuperGood::SolidusTaxjar::OrderTransaction",
             dependent: :destroy,
             inverse_of: :order
+
+          base.has_many :taxjar_transaction_sync_logs,
+            class_name: "SuperGood::SolidusTaxjar::TransactionSyncLog",
+            inverse_of: :order
         end
 
         ::Spree::Order.prepend self

--- a/db/migrate/20220912182210_allow_null_transaction_sync_batches_on_logs.rb
+++ b/db/migrate/20220912182210_allow_null_transaction_sync_batches_on_logs.rb
@@ -1,0 +1,5 @@
+class AllowNullTransactionSyncBatchesOnLogs < ActiveRecord::Migration[6.1]
+  def change
+    change_column :solidus_taxjar_transaction_sync_logs, :transaction_sync_batch_id, :integer, null: true
+  end
+end

--- a/lib/super_good/solidus_taxjar/testing_support/factories/configuration_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/configuration_factory.rb
@@ -1,3 +1,7 @@
 FactoryBot.define do
-  factory :taxjar_configuration, class: "SuperGood::SolidusTaxjar::Configuration"
+  factory :taxjar_configuration, class: "SuperGood::SolidusTaxjar::Configuration" do
+    trait :reporting_enabled do
+      preferred_reporting_enabled { true }
+    end
+  end
 end

--- a/lib/super_good/solidus_taxjar/testing_support/factories/configuration_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/configuration_factory.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     trait :reporting_enabled do
       preferred_reporting_enabled { true }
     end
+
+    trait :reporting_disabled do
+      preferred_reporting_enabled { false }
+    end
   end
 end

--- a/spec/features/spree/admin/reporting_to_taxjar_spec.rb
+++ b/spec/features/spree/admin/reporting_to_taxjar_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.feature 'Reporting orders to TaxJar', js: true, vcr: true do
+  stub_authorization!
+
+  background do
+    create :store, default: true
+    create :taxjar_configuration, :reporting_enabled
+  end
+
+  let!(:order) { create :order_ready_to_ship }
+
+  scenario "shipping a complete and paid order", vcr: { allow_unused_http_interactions: false } do
+    visit spree.edit_admin_order_path(order)
+    perform_enqueued_jobs do
+      wait_for_order_information_to_load
+      click_on "Ship"
+      expect(page).to have_content("Shipped package from")
+    end
+    # Ensure that the order has actually been reported to TaxJar
+    # and a record has been made.
+    expect(order.reload.taxjar_order_transactions.count).to eq(1)
+  end
+
+  def wait_for_order_information_to_load
+    expect(page).not_to have_content("Loading")
+  end
+end

--- a/spec/features/spree/admin/reporting_to_taxjar_spec.rb
+++ b/spec/features/spree/admin/reporting_to_taxjar_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature 'Reporting orders to TaxJar', js: true, vcr: true do
   background do
     create :store, default: true
     create :taxjar_configuration, :reporting_enabled
+
+    allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
   end
 
   let!(:order) { create :order_ready_to_ship }
@@ -17,9 +19,9 @@ RSpec.feature 'Reporting orders to TaxJar', js: true, vcr: true do
       click_on "Ship"
       expect(page).to have_content("Shipped package from")
     end
-    # Ensure that the order has actually been reported to TaxJar
-    # and a record has been made.
-    expect(order.reload.taxjar_order_transactions.count).to eq(1)
+
+    expect(page).to have_text("Reported to TaxJar at: #{Date.current.strftime("%B %d, %Y")}", normalize_ws: true)
+    expect(page).to have_text("TaxJar Sync: Success", normalize_ws: true)
   end
 
   def wait_for_order_information_to_load

--- a/spec/fixtures/cassettes/Reporting_orders_to_TaxJar/shipping_a_complete_and_paid_order.yml
+++ b/spec/fixtures/cassettes/Reporting_orders_to_TaxJar/shipping_a_complete_and_paid_order.yml
@@ -1,0 +1,323 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
+        Different Road","line_items":[{"id":1,"quantity":1,"unit_price":"10.0","discount":0,"product_tax_code":"TaxCode
+        - 116580"}],"shipping":"100.0"}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.7.6-p219; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1487'
+      Connection:
+      - close
+      Date:
+      - Mon, 12 Sep 2022 18:07:49 GMT
+      X-Amzn-Requestid:
+      - a1a21ba5-bad5-4bec-a3aa-1f1791af5230
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - YW9KdHBCoAMFYtw=
+      X-Amzn-Trace-Id:
+      - Root=1-631f7575-3da458665f0da05d108e27ed
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 bd6f70221217681265382902c6157c76.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA73-P2
+      X-Amz-Cf-Id:
+      - D6WcPTsmg7z3hy0qyxLRApetUr7-91quz5DKINYCpOvxUErUU-EeZA==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"amount_to_collect":9.76,"breakdown":{"city_tax_collectable":5.36,"city_tax_rate":0.04875,"city_taxable_amount":110.0,"combined_tax_rate":0.08875,"county_tax_collectable":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"line_items":[{"city_amount":0.49,"city_tax_rate":0.04875,"city_taxable_amount":10.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"id":"1","special_district_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_amount":0.4,"state_sales_tax_rate":0.04,"state_taxable_amount":10.0,"tax_collectable":0.89,"taxable_amount":10.0}],"shipping":{"city_amount":4.88,"city_tax_rate":0.04875,"city_taxable_amount":100.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_amount":4.0,"state_sales_tax_rate":0.04,"state_taxable_amount":100.0,"tax_collectable":8.88,"taxable_amount":100.0},"special_district_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_tax_collectable":4.4,"state_tax_rate":0.04,"state_taxable_amount":110.0,"tax_collectable":9.76,"taxable_amount":110.0},"freight_taxable":true,"has_nexus":true,"jurisdictions":{"city":"NEW
+        YORK CITY","country":"US","county":"QUEENS","state":"NY"},"order_total_amount":110.0,"rate":0.08875,"shipping":100.0,"tax_source":"destination","taxable_amount":110.0}}'
+    http_version:
+  recorded_at: Mon, 12 Sep 2022 18:07:49 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
+        Different Road","line_items":[{"id":1,"quantity":1,"unit_price":"10.0","discount":0,"product_tax_code":"TaxCode
+        - 116580"}],"shipping":"100.0"}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.7.6-p219; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1487'
+      Connection:
+      - close
+      Date:
+      - Mon, 12 Sep 2022 18:07:50 GMT
+      X-Amzn-Requestid:
+      - f5e8d19a-93e4-42c0-80c0-c4dbca031c38
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - YW9KlHNYoAMFSDA=
+      X-Amzn-Trace-Id:
+      - Root=1-631f7576-745b229b76091eaa41aa890b
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 0800f067ff646622f3e8e507cb9b52e8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA73-P2
+      X-Amz-Cf-Id:
+      - 828UC-AZF6UVeVraCcfHQb8kSv72X1Jbni6WDPxqRLDkyp_iZ8fH6A==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"amount_to_collect":9.76,"breakdown":{"city_tax_collectable":5.36,"city_tax_rate":0.04875,"city_taxable_amount":110.0,"combined_tax_rate":0.08875,"county_tax_collectable":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"line_items":[{"city_amount":0.49,"city_tax_rate":0.04875,"city_taxable_amount":10.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"id":"1","special_district_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_amount":0.4,"state_sales_tax_rate":0.04,"state_taxable_amount":10.0,"tax_collectable":0.89,"taxable_amount":10.0}],"shipping":{"city_amount":4.88,"city_tax_rate":0.04875,"city_taxable_amount":100.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_amount":4.0,"state_sales_tax_rate":0.04,"state_taxable_amount":100.0,"tax_collectable":8.88,"taxable_amount":100.0},"special_district_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_tax_collectable":4.4,"state_tax_rate":0.04,"state_taxable_amount":110.0,"tax_collectable":9.76,"taxable_amount":110.0},"freight_taxable":true,"has_nexus":true,"jurisdictions":{"city":"NEW
+        YORK CITY","country":"US","county":"QUEENS","state":"NY"},"order_total_amount":110.0,"rate":0.08875,"shipping":100.0,"tax_source":"destination","taxable_amount":110.0}}'
+    http_version:
+  recorded_at: Mon, 12 Sep 2022 18:07:50 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/transactions/orders
+    body:
+      encoding: UTF-8
+      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
+        Different Road","line_items":[{"id":1,"quantity":1,"product_identifier":"SKU-1","description":"Product
+        #1 - 4216 - Master","product_tax_code":"TaxCode - 116580","unit_price":"10.0","discount":0,"sales_tax":"0.89"}],"transaction_id":"R083062363","transaction_date":"2022-09-12T18:07:50Z","amount":"110.0","shipping":"100.0","sales_tax":"9.77"}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.7.6-p219; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '643'
+      Connection:
+      - close
+      Date:
+      - Mon, 12 Sep 2022 18:08:14 GMT
+      X-Amzn-Requestid:
+      - 2ec6c5b6-f95e-42b6-a61b-f50cbf86ea2b
+      X-Amzn-Remapped-Content-Length:
+      - '643'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Request-Id:
+      - FxQvO3D2MEMzMepNfFVC
+      X-Api-Version:
+      - '2020-08-07'
+      X-Amz-Apigw-Id:
+      - YW9OVGBIIAMF67w=
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Amzn-Remapped-Server:
+      - Cowboy
+      X-Amzn-Remapped-Date:
+      - Mon, 12 Sep 2022 18:08:14 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 b47618c03bd47cf085f27b1e215f76cc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA73-P2
+      X-Amz-Cf-Id:
+      - Ya2YZRX6M8GUUz2JsBvULYAXSPsn8QgSPoMimXcee87l0cnCy72P8g==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R083062363","transaction_date":"2022-09-12T18:07:50.000Z","to_zip":"11430","to_street":"A
+        Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
+        - 116580","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 4216 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
+    http_version:
+  recorded_at: Mon, 12 Sep 2022 18:08:14 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"customer_id":"1","to_country":"US","to_zip":"11430","to_city":"Herndon","to_state":"NY","to_street":"A
+        Different Road","line_items":[{"id":1,"quantity":1,"unit_price":"10.0","discount":0,"product_tax_code":"TaxCode
+        - 116580"}],"shipping":"100.0"}'
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.7.6-p219; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1487'
+      Connection:
+      - close
+      Date:
+      - Mon, 12 Sep 2022 18:08:15 GMT
+      X-Amzn-Requestid:
+      - 24e99cb8-d970-4f72-ad6a-3fb1d46557b7
+      Access-Control-Allow-Origin:
+      - https://developers.taxjar.com
+      X-Amz-Apigw-Id:
+      - YW9OaHYIoAMFZZQ=
+      X-Amzn-Trace-Id:
+      - Root=1-631f758f-143c6aff03ce24bb5873d7b4
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 ca66331b52971370c4e54619e8a952cc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA73-P2
+      X-Amz-Cf-Id:
+      - mrUEwIFYQ8iikXXY-8_pLi-BZ9hlYtfyo6cwn8cwB9F5e7dx3bJ5Ww==
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"amount_to_collect":9.76,"breakdown":{"city_tax_collectable":5.36,"city_tax_rate":0.04875,"city_taxable_amount":110.0,"combined_tax_rate":0.08875,"county_tax_collectable":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"line_items":[{"city_amount":0.49,"city_tax_rate":0.04875,"city_taxable_amount":10.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"id":"1","special_district_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_amount":0.4,"state_sales_tax_rate":0.04,"state_taxable_amount":10.0,"tax_collectable":0.89,"taxable_amount":10.0}],"shipping":{"city_amount":4.88,"city_tax_rate":0.04875,"city_taxable_amount":100.0,"combined_tax_rate":0.08875,"county_amount":0.0,"county_tax_rate":0.0,"county_taxable_amount":0.0,"special_district_amount":0.0,"special_tax_rate":0.0,"special_taxable_amount":0.0,"state_amount":4.0,"state_sales_tax_rate":0.04,"state_taxable_amount":100.0,"tax_collectable":8.88,"taxable_amount":100.0},"special_district_tax_collectable":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"state_tax_collectable":4.4,"state_tax_rate":0.04,"state_taxable_amount":110.0,"tax_collectable":9.76,"taxable_amount":110.0},"freight_taxable":true,"has_nexus":true,"jurisdictions":{"city":"NEW
+        YORK CITY","country":"US","county":"QUEENS","state":"NY"},"order_total_amount":110.0,"rate":0.08875,"shipping":100.0,"tax_source":"destination","taxable_amount":110.0}}'
+    http_version:
+  recorded_at: Mon, 12 Sep 2022 18:08:15 GMT
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/transactions/orders/R083062363
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - 'TaxJar/Ruby (Darwin Noahs-MacBook-Pro.local 20.6.0 Darwin Kernel Version
+        20.6.0: Mon Aug 30 06:12:21 PDT 2021; root:xnu-7195.141.6~3/RELEASE_X86_64
+        x86_64; ruby 2.7.6-p219; OpenSSL 1.1.1n  15 Mar 2022) taxjar-ruby/3.0.4'
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      X-Api-Version:
+      - '2020-08-07'
+      Plugin:
+      - supergoodsolidustaxjar
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '643'
+      Connection:
+      - close
+      Date:
+      - Mon, 12 Sep 2022 18:08:15 GMT
+      X-Amzn-Requestid:
+      - 3f63c476-9e96-42c7-b9a1-c43c7de4c558
+      X-Amzn-Remapped-Content-Length:
+      - '643'
+      X-Amzn-Remapped-Connection:
+      - keep-alive
+      X-Request-Id:
+      - FxQvO54psl5Ss9criHiD
+      X-Api-Version:
+      - '2020-08-07'
+      X-Amz-Apigw-Id:
+      - YW9OdHfcoAMFnLg=
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Amzn-Remapped-Server:
+      - Cowboy
+      X-Amzn-Remapped-Date:
+      - Mon, 12 Sep 2022 18:08:15 GMT
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 d2575afea3774df33dcf5e5ff475025e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - SEA73-P2
+      X-Amz-Cf-Id:
+      - QAfm1zj__NfckDUYqMEHSZs_su_vGjU-uxw_IJhoZhvnla_5PU6AHw==
+    body:
+      encoding: UTF-8
+      string: '{"order":{"user_id":225397,"transaction_reference_id":null,"transaction_id":"R083062363","transaction_date":"2022-09-12T18:07:50.000Z","to_zip":"11430","to_street":"A
+        Different Road","to_state":"NY","to_country":"US","to_city":"HERNDON","shipping":"100.0","sales_tax":"9.77","provider":"api","line_items":[{"unit_price":"10.0","sales_tax":"0.89","quantity":1,"product_tax_code":"TaxCode
+        - 116580","product_identifier":"SKU-1","id":0,"discount":"0.0","description":"Product
+        #1 - 4216 - Master"}],"from_zip":null,"from_street":null,"from_state":null,"from_country":"US","from_city":null,"exemption_type":null,"customer_id":"1","amount":"110.0"}}'
+    http_version:
+  recorded_at: Mon, 12 Sep 2022 18:08:15 GMT
+recorded_with: VCR 4.0.0

--- a/spec/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job_spec.rb
+++ b/spec/jobs/super_good/solidus_taxjar/backfill_transaction_sync_batch_job_spec.rb
@@ -2,7 +2,11 @@ require "spec_helper"
 
 RSpec.describe SuperGood::SolidusTaxjar::BackfillTransactionSyncBatchJob do
   describe "#perform" do
-    subject { described_class.new.perform(batch) }
+    subject do
+      perform_enqueued_jobs do
+        described_class.new.perform(batch)
+      end
+    end
 
     let!(:shipped_order) { create :shipped_order }
     let(:reporting_mock) { instance_double ::SuperGood::SolidusTaxjar::Reporting }

--- a/spec/jobs/super_good/solidus_taxjar/report_transaction_job_spec.rb
+++ b/spec/jobs/super_good/solidus_taxjar/report_transaction_job_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe SuperGood::SolidusTaxjar::ReportTransactionJob do
         )
     end
 
+    context "when a transaction sync batch is passed" do
+      subject { described_class.perform_now(order, transaction_sync_batch) }
+
+      let(:transaction_sync_batch) { create :transaction_sync_batch }
+
+      it "creates a transaction sync log associated with the given batch" do
+        expect { subject }
+          .to change { ::SuperGood::SolidusTaxjar::TransactionSyncLog.count }
+          .from(0)
+          .to(1)
+
+        expect(::SuperGood::SolidusTaxjar::TransactionSyncLog.last)
+          .to have_attributes(
+            transaction_sync_batch: transaction_sync_batch
+          )
+      end
+    end
+
     context "when syncing to taxjar fails" do
       before do
         allow(mock_reporting)

--- a/spec/jobs/super_good/solidus_taxjar/report_transaction_job_spec.rb
+++ b/spec/jobs/super_good/solidus_taxjar/report_transaction_job_spec.rb
@@ -1,24 +1,57 @@
 require "spec_helper"
 
 RSpec.describe SuperGood::SolidusTaxjar::ReportTransactionJob do
-  describe ".perform_later" do
-    subject { described_class.perform_later(order) }
+  describe ".perform_now" do
+    subject { described_class.perform_now(order) }
 
     let(:order) { create :order }
     let(:mock_reporting) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
+    let(:fake_order_transaction) { create :taxjar_order_transaction }
 
-    it "enqueues the job" do
-      assert_enqueued_with(job: described_class, args: [order]) do
-        subject
-      end
+    before do
+      allow(mock_reporting)
+        .to receive(:show_or_create_transaction)
+        .and_return(fake_order_transaction)
+      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(mock_reporting)
     end
 
     it "reports the transaction when it performs the job" do
-      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(mock_reporting)
-      expect(mock_reporting).to receive(:show_or_create_transaction).with(order)
+      subject
 
-      perform_enqueued_jobs do
-        subject
+      expect(mock_reporting).to have_received(:show_or_create_transaction).with(order)
+    end
+
+    it "creates a transaction sync log with the order transaction" do
+      expect { subject }
+        .to change { ::SuperGood::SolidusTaxjar::TransactionSyncLog.count }
+        .from(0)
+        .to(1)
+
+      expect(::SuperGood::SolidusTaxjar::TransactionSyncLog.last)
+        .to have_attributes(
+          status: "success",
+          order_transaction: fake_order_transaction
+        )
+    end
+
+    context "when syncing to taxjar fails" do
+      before do
+        allow(mock_reporting)
+        .to receive(:show_or_create_transaction)
+        .and_raise(Taxjar::Error.new("something bad"))
+      end
+
+      it "creates a transaction sync log with the error message" do
+        expect { subject }
+          .to change { ::SuperGood::SolidusTaxjar::TransactionSyncLog.count }
+          .from(0)
+          .to(1)
+
+        expect(::SuperGood::SolidusTaxjar::TransactionSyncLog.last)
+          .to have_attributes(
+            status: "error",
+            error_message: "something bad"
+          )
       end
     end
   end

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::OrdersController, :type => :request do
+  include Capybara::RSpecMatchers
+
+  extend Spree::TestingSupport::AuthorizationHelpers::Request
+  stub_authorization!
+
+  describe "#edit" do
+    subject { get spree.edit_admin_order_path(order) }
+
+    let!(:order) { create(:shipped_order) }
+
+    before do
+      allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
+    end
+
+    it "displays an empty value for the TaxJar reported at time" do
+      subject
+      expect(response.body).to have_text("Reported to TaxJar at: -", normalize_ws: true)
+    end
+
+    context "if the order has reported transactions" do
+      before do
+        create :transaction_sync_log, :success, order: order, created_at: DateTime.new(2022,01,01,12,12)
+        create :transaction_sync_log, :success, order: order, created_at: DateTime.new(2022,06,06,12,12)
+      end
+
+      it "displays the date and time of the most recent transaction sync" do
+        subject
+        expect(response.body).to have_text("Reported to TaxJar at: June 06, 2022 12:12 PM", normalize_ws: true)
+      end
+    end
+
+    context "when the reporting UI is disabled" do
+      before do
+        allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(false)
+      end
+
+      it "does not show the reported at time" do
+        subject
+        expect(response.body).not_to have_text("Reported to TaxJar at")
+      end
+    end
+  end
+end

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -10,9 +10,20 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
     subject { get spree.edit_admin_order_path(order) }
 
     let!(:order) { create(:shipped_order) }
+    let(:reporting_enabled) { true }
 
     before do
       allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
+    end
+
+    around do |example|
+      begin
+        old_value = SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled
+        SuperGood::SolidusTaxjar.configuration.update!(preferred_reporting_enabled: reporting_enabled)
+        example.run
+      ensure
+        SuperGood::SolidusTaxjar.configuration.update!(preferred_reporting_enabled: old_value)
+      end
     end
 
     it "displays an empty value for the TaxJar reported at time" do
@@ -20,15 +31,61 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
       expect(response.body).to have_text("Reported to TaxJar at: -", normalize_ws: true)
     end
 
+    it "displays a 'pending' status" do
+      subject
+      expect(response.body).to have_text("TaxJar Sync: Pending", normalize_ws: true)
+    end
+
     context "if the order has reported transactions" do
+      let(:latest_sync_log_status) { :success }
+
       before do
         create :transaction_sync_log, :success, order: order, created_at: DateTime.new(2022,01,01,12,12)
-        create :transaction_sync_log, :success, order: order, created_at: DateTime.new(2022,06,06,12,12)
+        create(
+          :transaction_sync_log,
+          order: order,
+          created_at: DateTime.new(2022,06,06,12,12),
+          order_transaction: create(:taxjar_order_transaction, order: order),
+          status: latest_sync_log_status
+        )
       end
 
       it "displays the date and time of the most recent transaction sync" do
         subject
         expect(response.body).to have_text("Reported to TaxJar at: June 06, 2022 12:12 PM", normalize_ws: true)
+      end
+
+      it "displays the status of the transaction sync log" do
+        subject
+        expect(response.body).to have_text("TaxJar Sync: #{latest_sync_log_status.capitalize}", normalize_ws: true)
+      end
+    end
+
+    context "when transaction syncing is turned off" do
+      let(:reporting_enabled) { false }
+
+      it "displays a 'disabled' status" do
+        subject
+        expect(response.body).to have_text("TaxJar Sync: Disabled", normalize_ws: true)
+      end
+
+      context "and a transaction sync log exists" do
+        let(:latest_sync_log_status) { :success }
+
+        before do
+          create(
+            :transaction_sync_log,
+            order: order,
+            created_at: DateTime.new(2022,06,06,12,12),
+            order_transaction: create(:taxjar_order_transaction, order: order),
+            status: latest_sync_log_status
+          )
+        end
+
+        it "displays the status of the transaction sync log" do
+          subject
+          expect(response.body).to have_text("TaxJar Sync: #{latest_sync_log_status.capitalize}", normalize_ws: true)
+        end
       end
     end
 


### PR DESCRIPTION
What is the goal of this PR?
---

We should display the status of the most recent transaction on the status of an ordwr

How do you manually test these changes? (if applicable)
---

1. Report an order to taxjar
    * [x] Ensure the date and time of the latest sync is shown on the order page
    * [x] Ensure the status of the order sync is shown on the order page

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog

Screenshots
---
![Screen Shot 2022-10-03 at 11 21 25PDT](https://user-images.githubusercontent.com/8933450/193650321-6b65a684-123f-4079-9091-fdaedb3785b3.png)
![Screen Shot 2022-10-03 at 11 21 11PDT](https://user-images.githubusercontent.com/8933450/193650325-6460ef29-88f4-4a29-a7c5-3d6000700e74.png)
![Screen Shot 2022-10-03 at 11 20 49PDT](https://user-images.githubusercontent.com/8933450/193650327-70e09265-25b2-4616-8d5d-0a7302ef394f.png)
![Screen Shot 2022-10-03 at 11 20 40PDT](https://user-images.githubusercontent.com/8933450/193650328-51994cbd-ce3a-46b9-8197-66c7188b0c95.png)
![Screen Shot 2022-10-03 at 11 19 45PDT](https://user-images.githubusercontent.com/8933450/193650332-f1ec096d-f5b8-473a-a2d7-fa6faa159c01.png)


