### PR TITLE
Remove outdated backfill button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@
 - [#195](https://github.com/SuperGoodSoft/solidus_taxjar/pull/195) Run transaction backfills asynchronously
 - [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/200) Expand solidus gem into dependencies to support Solidus 3.2+
 - [#183](https://github.com/SuperGoodSoft/solidus_taxjar/pull/183) Add ability to fetch tax codes from TaxJar and assign to tax categories in admin
-- [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/199) Render error message when backfilling transactions fails
+- [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/200) Render error message when backfilling transactions fails
+- [#203](https://github.com/SuperGoodSoft/solidus_taxjar/pull/203) Remove outdated backfill button
 
 ## Upgrading Instructions
 

--- a/app/views/spree/admin/taxjar_settings/edit.html.erb
+++ b/app/views/spree/admin/taxjar_settings/edit.html.erb
@@ -16,7 +16,4 @@
     <p>Sync orders and refund with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</p>
     <%= form.submit %>
   <% end %>
-  <%= form_with url: admin_taxjar_settings_backfill_transactions_path, method: :post, local: true do %>
-    <%= submit_tag "Backfill Transactions" %>
-  <% end %>
 <% end %>


### PR DESCRIPTION
What is the goal of this PR?
---

This button has been replaced by a tab and is no longer needed

How do you manually test these changes? (if applicable)
---

1. Visit the taxjar settings page
    * [x] Ensure the backfill button is not present

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog

Screenshots
---

**Before**

<img width="833" alt="Screen Shot 2022-10-07 at 13 28 58PDT" src="https://user-images.githubusercontent.com/8933450/194647668-06fda806-f995-42a7-bd0c-c8cf58200b30.png">


**After**

<img width="770" alt="Screen Shot 2022-10-07 at 13 28 21PDT" src="https://user-images.githubusercontent.com/8933450/194647681-9de4d2fb-d5ee-4301-83dd-7a9940f6269f.png">

