### PR TITLE
[186] Add page to display taxjar transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [#200](https://github.com/SuperGoodSoft/solidus_taxjar/pull/200) Render error message when backfilling transactions fails
 - [#203](https://github.com/SuperGoodSoft/solidus_taxjar/pull/203) Remove outdated backfill button
 - [#202](https://github.com/SuperGoodSoft/solidus_taxjar/pull/202) Add TaxJar transaction sync status to order show page
+- [#204](https://github.com/SuperGoodSoft/solidus_taxjar/pull/204) Add page to render an orders TaxJar transactions
 
 ## Upgrading Instructions
 

--- a/app/overrides/spree/admin/orders_controller_override.rb
+++ b/app/overrides/spree/admin/orders_controller_override.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Admin
+    module OrdersControllerOverride
+      def taxjar_transactions
+        load_order
+      end
+
+      Spree::Admin::OrdersController.prepend self
+    end
+  end
+end

--- a/app/overrides/spree/admin/shared/_order_submenu/add_taxjar_sync_history_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_submenu/add_taxjar_sync_history_tab.html.erb.deface
@@ -1,0 +1,6 @@
+
+<!-- insert_bottom "[data-hook='admin_order_tabs']" -->
+
+<li class="<%= "active" if current == "TaxJar Sync History" %>" data-hook='admin_order_tabs_order_details'>
+  <%= link_to "TaxJar Sync History", spree.taxjar_transactions_admin_order_path(@order) %>
+</li>

--- a/app/views/spree/admin/orders/taxjar_transactions.html.erb
+++ b/app/views/spree/admin/orders/taxjar_transactions.html.erb
@@ -1,3 +1,5 @@
 <% content_for :page_title do %>
   <%= "TaxJar Sync History - Order " + @order.number %>
 <% end %>
+
+<%= render 'spree/admin/shared/transaction_sync_log_table', transaction_sync_logs: @order.taxjar_transaction_sync_logs %>

--- a/app/views/spree/admin/orders/taxjar_transactions.html.erb
+++ b/app/views/spree/admin/orders/taxjar_transactions.html.erb
@@ -1,5 +1,4 @@
-<% content_for :page_title do %>
-  <%= "TaxJar Sync History - Order " + @order.number %>
-<% end %>
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: 'TaxJar Sync History' } %>
+<% admin_breadcrumb("TaxJar Sync History") %>
 
 <%= render 'spree/admin/shared/transaction_sync_log_table', transaction_sync_logs: @order.taxjar_transaction_sync_logs %>

--- a/app/views/spree/admin/orders/taxjar_transactions.html.erb
+++ b/app/views/spree/admin/orders/taxjar_transactions.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title do %>
+  <%= "TaxJar Sync History - Order " + @order.number %>
+<% end %>

--- a/app/views/spree/admin/shared/_transaction_sync_log_table.html.erb
+++ b/app/views/spree/admin/shared/_transaction_sync_log_table.html.erb
@@ -1,0 +1,26 @@
+<table>
+  <thead>
+    <tr>
+      <th>Log ID</th>
+      <th>Order</th>
+      <th>TaxJar Transaction ID</th>
+      <th>Status</th>
+      <th>Error Message</th>
+      <th>Created at</th>
+      <th>Updated at</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% transaction_sync_logs.each do |log| %>
+      <tr>
+        <td><%= log.id %></td>
+        <td><%= link_to log.order.number, spree.edit_admin_order_path(log.order) %></td>
+        <td><%= log.order_transaction&.transaction_id || "-" %></td>
+        <td><%= log.status.capitalize %></td>
+        <td style="white-space: pre-wrap; width: 150px; overflow-wrap: anywhere;"><%= log.error_message %></td>
+        <td><%= log.created_at %></td>
+        <td><%= log.updated_at %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/spree/admin/transaction_sync_batches/show.html.erb
+++ b/app/views/spree/admin/transaction_sync_batches/show.html.erb
@@ -4,30 +4,4 @@
   <%= "Transaction Sync Batch #{@batch.id}" %>
 <% end %>
 
-<table id="transaction_sync_batch_logs">
-  <thead>
-    <tr>
-      <th>Log ID</th>
-      <th>Order</th>
-      <th>TaxJar Transaction ID</th>
-      <th>Status</th>
-      <th>Error Message</th>
-      <th>Created at</th>
-      <th>Updated at</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @batch.transaction_sync_logs.each do |log| %>
-      <tr>
-        <td><%= log.id %></td>
-        <td><%= link_to log.order.number, spree.edit_admin_order_path(log.order) %></td>
-        <td><%= log.order_transaction&.transaction_id || "-" %></td>
-        <td><%= log.status.capitalize %></td>
-        <td style="white-space: pre-wrap; width: 150px;"><%= log.error_message %></td>
-        <td><%= log.created_at %></td>
-        <td><%= log.updated_at %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
+<%= render 'spree/admin/shared/transaction_sync_log_table', transaction_sync_logs: @batch.transaction_sync_logs %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,11 @@ Spree::Core::Engine.routes.draw do
     get 'taxjar_settings/sync_nexus_regions', to: 'taxjar_settings#sync_nexus_regions'
     get 'taxjar_settings/sync_tax_categories', to: 'taxjar_settings#sync_tax_categories'
     post 'taxjar_settings/backfill_transactions', to: 'taxjar_settings#backfill_transactions'
+
+    resources :orders do
+      member do
+        get :taxjar_transactions
+      end
+    end
   end
 end

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
         end
       end
       expect(page).to have_content /Transaction Sync Batch \d/
-      within "#transaction_sync_batch_logs" do
+      within ".content-wrapper table" do
         expect(page).to have_content order.number
         within "tbody td:nth-child(4)" do
           expect(page).to have_content("Success")
@@ -87,7 +87,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
         find(".fa-edit").click
       end
 
-      within "#transaction_sync_batch_logs" do
+      within ".content-wrapper table" do
         within "tbody tr:first-child" do
           within "td:first-child" do
             expect(page).to have_content(processing_transaction_sync_log.id)

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
   extend Spree::TestingSupport::AuthorizationHelpers::Request
   stub_authorization!
 
+  before do
+    allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
+  end
+
   describe "#edit" do
     subject { get spree.edit_admin_order_path(order) }
 
     let!(:order) { create(:shipped_order) }
     let(:reporting_enabled) { true }
-
-    before do
-      allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
-    end
 
     around do |example|
       begin
@@ -98,6 +98,17 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
         subject
         expect(response.body).not_to have_text("Reported to TaxJar at")
       end
+    end
+  end
+
+  describe "#taxjar_transactions" do
+    subject { get spree.taxjar_transactions_admin_order_path(order) }
+
+    let!(:order) { create(:shipped_order) }
+
+    it "renders the taxjar transactions page for the order" do
+      subject
+      expect(response.body).to have_content("TaxJar Sync History - Order #{order.number}")
     end
   end
 end

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
       expect(response.body).to have_text("TaxJar Sync: Pending", normalize_ws: true)
     end
 
+    it "displays a link to view the TaxJar Sync History" do
+      subject
+      expect(response.body).to have_link("TaxJar Sync History", href: spree.taxjar_transactions_admin_order_path(order))
+    end
+
     context "if the order has reported transactions" do
       let(:latest_sync_log_status) { :success }
 
@@ -113,7 +118,7 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
 
     it "renders the taxjar transactions page for the order" do
       subject
-      expect(response.body).to have_content("TaxJar Sync History - Order #{order.number}")
+      expect(response.body).to have_text(/TaxJar Sync History - #?#{order.number} - Orders/)
     end
 
     it "renders the transaction sync logs" do

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -105,10 +105,20 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
     subject { get spree.taxjar_transactions_admin_order_path(order) }
 
     let!(:order) { create(:shipped_order) }
+    let(:order_transaction) { create :taxjar_order_transaction, transaction_id: "Test-123"}
+
+    before do
+      create :transaction_sync_log, order: order, order_transaction: order_transaction, status: :success
+    end
 
     it "renders the taxjar transactions page for the order" do
       subject
       expect(response.body).to have_content("TaxJar Sync History - Order #{order.number}")
+    end
+
+    it "renders the transaction sync logs" do
+      subject
+      expect(response.body).to have_text("#{order.number} Test-123 Success", normalize_ws: true)
     end
   end
 end


### PR DESCRIPTION
What is the goal of this PR?
---

Users should be able to easily view the transaction sync history for an order

How do you manually test these changes? (if applicable)
---

1. Create a order with some taxjar transactions
    * [x] Ensure that you can click on the "TaxJar Sync History" tab and view the transactions
* [x] Smoke test viewing backfill logs

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog

Screenshots
---

<img width="1501" alt="Screen Shot 2022-10-07 at 14 14 15PDT" src="https://user-images.githubusercontent.com/8933450/194653621-ed902477-7dee-48d2-af9e-f5424130b673.png">
