### PR TITLE
Remove `reporting_ui_enabled` flag from app

### DIFF
--- a/app/overrides/spree/admin/shared/_configuration_menu.rb
+++ b/app/overrides/spree/admin/shared/_configuration_menu.rb
@@ -8,8 +8,6 @@ Deface::Override.new(
   <<-HTML
     <%= configurations_sidebar_menu_item "TaxJar Settings", edit_admin_taxjar_settings_path %>
 
-    <% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
-      <%= configurations_sidebar_menu_item "TaxJar Backfill", admin_transaction_sync_batches_path %>
-    <% end %>
+    <%= configurations_sidebar_menu_item "TaxJar Backfill", admin_transaction_sync_batches_path %>
   HTML
 end

--- a/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
@@ -9,22 +9,20 @@
   </style>
 <% end %>
 
-<% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
-  <% last_sync_log = @order.taxjar_transaction_sync_logs.order(:created_at).last %>
-  <dt>Reported to TaxJar at:</dt>
-  <dd> <%= last_sync_log ? pretty_time(last_sync_log.created_at) : "-" %></dd>
-  <dt>TaxJar Sync: </dt>
-  <dd>
-    <% last_sync_log_status = if last_sync_log
-        last_sync_log.status
-      else
-        SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled ?
-          "pending" :
-          "disabled"
-      end
-    %>
-    <span class="pill pill-<%= last_sync_log_status %>">
-      <%= last_sync_log_status.capitalize %>
-    </span>
-  </dd>
-<% end
+<% last_sync_log = @order.taxjar_transaction_sync_logs.order(:created_at).last %>
+<dt>Reported to TaxJar at:</dt>
+<dd> <%= last_sync_log ? pretty_time(last_sync_log.created_at) : "-" %></dd>
+<dt>TaxJar Sync: </dt>
+<dd>
+  <% last_sync_log_status = if last_sync_log
+      last_sync_log.status
+    else
+      SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled ?
+        "pending" :
+        "disabled"
+    end
+  %>
+  <span class="pill pill-<%= last_sync_log_status %>">
+    <%= last_sync_log_status.capitalize %>
+  </span>
+</dd>

--- a/app/views/spree/admin/taxjar_settings/edit.html.erb
+++ b/app/views/spree/admin/taxjar_settings/edit.html.erb
@@ -6,14 +6,12 @@
 
 <%= render 'nexus_regions' %>
 <%= render 'tax_categories' %>
-<% if SuperGood::SolidusTaxjar.reporting_ui_enabled %>
-  <%= form_with model: @configuration, url: admin_taxjar_settings_path, method: :put, local: true do |form| %>
-    <%= render "spree/admin/shared/preference_fields/boolean",
-          attribute:  :preferred_reporting_enabled,
-          label: "Transaction Sync",
-          form: form
-    %>
-    <p>Sync orders and refund with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</p>
-    <%= form.submit %>
-  <% end %>
+<%= form_with model: @configuration, url: admin_taxjar_settings_path, method: :put, local: true do |form| %>
+  <%= render "spree/admin/shared/preference_fields/boolean",
+        attribute:  :preferred_reporting_enabled,
+        label: "Transaction Sync",
+        form: form
+  %>
+  <p>Sync orders and refund with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</p>
+  <%= form.submit %>
 <% end %>

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -26,7 +26,6 @@ module SuperGood
       attr_accessor :job_queue
       attr_accessor :line_item_tax_label_maker
       attr_accessor :logging_enabled
-      attr_accessor :reporting_ui_enabled
       attr_accessor :shipping_calculator
       attr_accessor :shipping_tax_label_maker
       attr_accessor :taxable_address_check
@@ -68,10 +67,6 @@ module SuperGood
     self.job_queue = :default
     self.line_item_tax_label_maker = ->(taxjar_line_item, spree_line_item) { "Sales Tax" }
     self.logging_enabled = true
-
-    # The reporting setting in the admin UI is disabled for now till the reporting
-    # feature is fully implemented.
-    self.reporting_ui_enabled = false
 
     self.shipping_calculator = ->(order) { order.shipments.sum(&:total_before_tax) }
     self.shipping_tax_label_maker = ->(shipment, shipping_tax) { "Sales Tax" }

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -7,11 +7,6 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
     create :store, default: true
   end
 
-  before do
-    allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
-  end
-
-
   feature "user has a shipped order" do
     let!(:order) { create :shipped_order }
 

--- a/spec/features/spree/admin/reporting_to_taxjar_spec.rb
+++ b/spec/features/spree/admin/reporting_to_taxjar_spec.rb
@@ -6,8 +6,6 @@ RSpec.feature 'Reporting orders to TaxJar', js: true, vcr: true do
   background do
     create :store, default: true
     create :taxjar_configuration, :reporting_enabled
-
-    allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
   end
 
   let!(:order) { create :order_ready_to_ship }

--- a/spec/features/spree/admin/taxjar_settings_spec.rb
+++ b/spec/features/spree/admin/taxjar_settings_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Admin TaxJar Settings', js: true, vcr: true do
     before do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("TAXJAR_API_KEY").and_return(api_token)
-      allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
     end
 
     scenario "the user navigates to the TaxJar Settings" do

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
     let!(:order) { create(:shipped_order) }
     let(:reporting_enabled) { true }
 
-    before do
-      allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
-    end
-
     around do |example|
       begin
         old_value = SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled
@@ -86,17 +82,6 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
           subject
           expect(response.body).to have_text("TaxJar Sync: #{latest_sync_log_status.capitalize}", normalize_ws: true)
         end
-      end
-    end
-
-    context "when the reporting UI is disabled" do
-      before do
-        allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(false)
-      end
-
-      it "does not show the reported at time" do
-        subject
-        expect(response.body).not_to have_text("Reported to TaxJar at")
       end
     end
   end

--- a/spec/super_good/solidus_taxjar_spec.rb
+++ b/spec/super_good/solidus_taxjar_spec.rb
@@ -101,14 +101,6 @@ RSpec.describe SuperGood::SolidusTaxjar do
       it { is_expected.to eq false }
     end
 
-    describe ".reporting_ui_enabled" do
-      subject { described_class.reporting_ui_enabled }
-
-      it "it defaults to false" do
-        expect(subject).to eq false
-      end
-    end
-
     describe ".exception_handler" do
       subject { described_class.exception_handler.call(exception) }
 


### PR DESCRIPTION

What is the goal of this PR?
---

The reporting feature is nearly ready for release, and we should remove the UI feature flag in preparation for that.

How do you manually test these changes? (if applicable)
---

* [ ] View the reporting UI in the sandbox app

Merge Checklist
---

- [x] Run the manual tests
- [ ] Update the changelog

