### PR TITLE
Update spec setup to reset state in `before` block

### DIFF
--- a/spec/super_good/solidus_taxjar/calculator_helper_spec.rb
+++ b/spec/super_good/solidus_taxjar/calculator_helper_spec.rb
@@ -24,12 +24,18 @@ RSpec.describe SuperGood::SolidusTaxjar::CalculatorHelper do
     end
 
     context "with a missing state in CA" do
-      let(:address) { build :address, country_iso_code: "CA", state: nil }
+      let(:address) { build :address, country_iso_code: "CA" }
+
+      before { address.state = nil }
+
       it { is_expected.to eq(true) }
     end
 
     context "with a missing state in US" do
-      let(:address) { build :address, country_iso_code: "US", state: nil }
+      let(:address) { build :address, country_iso_code: "US" }
+
+      before { address.state = nil }
+
       it { is_expected.to eq(true) }
     end
 


### PR DESCRIPTION
What is the goal of this PR?
---
This change fixes the specs against the `master` Solidus branch in preparation for the 1.0 release of this gem.

In a recent change to core, an `after(:build)` hook was added to set the state on the address record for countries which require states. This interferes with the spec setup by ignoring the state attribute we were setting to `nil`. Instead we have moved that to a `before` block so that we can correctly setup the test address to not have a state.

Relevant change upstream - https://github.com/solidusio/solidus/pull/4272

How do you manually test these changes? (if applicable)
---

1. N/A

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
