### PR TITLE
Add `deface` as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [#201](https://github.com/SuperGoodSoft/solidus_taxjar/pull/201) Allow transaction backfills to be filtered by date range
 - [#205](https://github.com/SuperGoodSoft/solidus_taxjar/pull/205) Use nexus regions for taxable address checks
 - [#218](https://github.com/SuperGoodSoft/solidus_taxjar/pull/218) Removed `order_recalculated` event backport
+- [#216](https://github.com/SuperGoodSoft/solidus_taxjar/pull/216) Add `deface` as a dependency.
 
 ## Upgrading Instructions
 

--- a/lib/super_good/solidus_taxjar.rb
+++ b/lib/super_good/solidus_taxjar.rb
@@ -1,5 +1,6 @@
 require "solidus_core"
 require "solidus_support"
+require "deface"
 require "taxjar"
 require "super_good/solidus_taxjar/overrides/request_override"
 

--- a/super_good-solidus_taxjar.gemspec
+++ b/super_good-solidus_taxjar.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "deface", ">= 1"
   spec.add_dependency "solidus_core", ">= 2.4.0"
   spec.add_dependency "solidus_support", ">= 0.9.0"
   spec.add_dependency "taxjar-ruby"


### PR DESCRIPTION
What is the goal of this PR?
---

Because our test application includes `solidus_auth_devise`, which depends on `deface`, we didn't realize that we needed to explicitly depend on `deface`. We wrongly thought it would be available to all Solidus stores.

This commit should resolve issue #212.


How do you manually test these changes? (if applicable)
---

I would like to manually ensure the admin interface is working as intended to ensure we aren't creating problems for end users, like reported in [this comment](https://github.com/SuperGoodSoft/solidus_taxjar/issues/212#issuecomment-1404261063).

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
