### PR TITLE
Handle updates to orders that have not been reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - [#205](https://github.com/SuperGoodSoft/solidus_taxjar/pull/205) Use nexus regions for taxable address checks
 - [#218](https://github.com/SuperGoodSoft/solidus_taxjar/pull/218) Removed `order_recalculated` event backport
 - [#216](https://github.com/SuperGoodSoft/solidus_taxjar/pull/216) Add `deface` as a dependency.
+- [#217](https://github.com/SuperGoodSoft/solidus_taxjar/pull/217) Handle updates to orders that have not been reported
 
 ## Upgrading Instructions
 

--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -41,7 +41,10 @@ module Spree
       end
 
       def configuration_params
-        params.require(:super_good_solidus_taxjar_configuration).permit(:preferred_reporting_enabled)
+        params_hash = params.require(:super_good_solidus_taxjar_configuration).permit(:preferred_reporting_enabled, :preferred_reporting_enabled_at_integer)
+        {
+          preferred_reporting_enabled_at_integer: params_hash[:preferred_reporting_enabled] == "1" ? DateTime.now.to_i : nil
+        }
       end
 
       def tax_category_params

--- a/app/models/super_good/solidus_taxjar/configuration.rb
+++ b/app/models/super_good/solidus_taxjar/configuration.rb
@@ -9,7 +9,8 @@ module SuperGood
       preference :reporting_enabled_at_integer, :integer, default: nil
 
       def preferred_reporting_enabled
-        preferred_reporting_enabled_at_integer.present?
+        preferred_reporting_enabled_at_integer.present? &&
+          DateTime.current.after?(preferred_reporting_enabled_at)
       end
 
       def preferred_reporting_enabled_at

--- a/app/models/super_good/solidus_taxjar/configuration.rb
+++ b/app/models/super_good/solidus_taxjar/configuration.rb
@@ -6,7 +6,15 @@ module SuperGood
       include ::Spree::Preferences::Persistable
 
       self.table_name = 'solidus_taxjar_configuration'
-      preference :reporting_enabled, :boolean, default: false
+      preference :reporting_enabled_at_integer, :integer, default: nil
+
+      def preferred_reporting_enabled
+        preferred_reporting_enabled_at_integer.present?
+      end
+
+      def preferred_reporting_enabled_at
+        Time.at(SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled_at_integer).to_datetime
+      end
 
       class << self
         def default

--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -21,6 +21,7 @@ module SuperGood
 
           if completed_before_reporting_enabled?(order)
             order.taxjar_transaction_sync_logs.create!(status: :error, error_message: ORDER_TOO_OLD_MESSAGE)
+            SuperGood::SolidusTaxjar.exception_handler.call(RuntimeError.new(ORDER_TOO_OLD_MESSAGE))
             return
           end
 
@@ -36,6 +37,7 @@ module SuperGood
 
           if completed_before_reporting_enabled?(order)
             order.taxjar_transaction_sync_logs.create!(status: :error, error_message: ORDER_TOO_OLD_MESSAGE)
+            SuperGood::SolidusTaxjar.exception_handler.call(RuntimeError.new(ORDER_TOO_OLD_MESSAGE))
             return
           end
 

--- a/lib/super_good/solidus_taxjar/testing_support/factories/configuration_factory.rb
+++ b/lib/super_good/solidus_taxjar/testing_support/factories/configuration_factory.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :taxjar_configuration, class: "SuperGood::SolidusTaxjar::Configuration" do
     trait :reporting_enabled do
-      preferred_reporting_enabled { true }
+      preferred_reporting_enabled_at_integer { DateTime.now.to_i }
     end
 
     trait :reporting_disabled do
-      preferred_reporting_enabled { false }
+      preferred_reporting_enabled_at_integer { nil }
     end
   end
 end

--- a/spec/models/super_good/solidus_taxjar/configuration_spec.rb
+++ b/spec/models/super_good/solidus_taxjar/configuration_spec.rb
@@ -19,15 +19,24 @@ RSpec.describe SuperGood::SolidusTaxjar::Configuration do
     it "has the default value" do
       expect(subject).to be_falsey
     end
+
+    context "reporting_enabled_at is set" do
+      let(:taxjar_configuration) { create(:taxjar_configuration, preferred_reporting_enabled_at_integer: DateTime.now.to_i) }
+
+      it "is true" do
+        expect(subject).to be_truthy
+      end
+    end
   end
 
-  describe "#preferred_reporting_enabled=" do
-    subject { taxjar_configuration.update(preferred_reporting_enabled: true) }
+  describe "#preferred_reporting_enabled_at" do
+    subject { taxjar_configuration.preferred_reporting_enabled_at }
 
-    let(:taxjar_configuration) { create(:taxjar_configuration) }
+    let(:taxjar_configuration) { create(:taxjar_configuration, preferred_reporting_enabled_at_integer: datetime_integer) }
+    let(:datetime_integer) { 1675116247 }
 
-    it "sets the value" do
-      expect { subject }.to change { taxjar_configuration.reload.preferred_reporting_enabled }.from(false).to(true)
+    it "parses the integer datetime" do
+      expect(subject).to eq DateTime.parse("Mon, 30 Jan 2023 22:04:07 +0000")
     end
   end
 

--- a/spec/models/super_good/solidus_taxjar/configuration_spec.rb
+++ b/spec/models/super_good/solidus_taxjar/configuration_spec.rb
@@ -20,11 +20,19 @@ RSpec.describe SuperGood::SolidusTaxjar::Configuration do
       expect(subject).to be_falsey
     end
 
-    context "reporting_enabled_at is set" do
+    context "reporting_enabled_at is set in the past" do
       let(:taxjar_configuration) { create(:taxjar_configuration, preferred_reporting_enabled_at_integer: DateTime.now.to_i) }
 
       it "is true" do
         expect(subject).to be_truthy
+      end
+    end
+
+    context "reporting_enabled_at is set in the future" do
+      let(:taxjar_configuration) { create(:taxjar_configuration, preferred_reporting_enabled_at_integer: (DateTime.now + 1.day).to_i) }
+
+      it "is false" do
+        expect(subject).to be_falsy
       end
     end
   end

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -6,23 +6,25 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
   extend Spree::TestingSupport::AuthorizationHelpers::Request
   stub_authorization!
 
-  before do
-    allow(SuperGood::SolidusTaxjar).to receive(:reporting_ui_enabled).and_return(true)
-  end
-
   describe "#edit" do
     subject { get spree.edit_admin_order_path(order) }
 
     let!(:order) { create(:shipped_order) }
-    let(:reporting_enabled) { true }
+    let(:reporting_enabled_at) { 1.day.ago.to_i }
 
     around do |example|
       begin
-        old_value = SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled
-        SuperGood::SolidusTaxjar.configuration.update!(preferred_reporting_enabled: reporting_enabled)
+        old_value = SuperGood::SolidusTaxjar
+          .configuration
+          .preferred_reporting_enabled_at_integer
+        SuperGood::SolidusTaxjar.configuration.update!(
+          preferred_reporting_enabled_at_integer: reporting_enabled_at
+        )
         example.run
       ensure
-        SuperGood::SolidusTaxjar.configuration.update!(preferred_reporting_enabled: old_value)
+        SuperGood::SolidusTaxjar.configuration.update!(
+          preferred_reporting_enabled_at_integer: old_value
+        )
       end
     end
 
@@ -67,7 +69,7 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
     end
 
     context "when transaction syncing is turned off" do
-      let(:reporting_enabled) { false }
+      let(:reporting_enabled_at) { nil }
 
       it "displays a 'disabled' status" do
         subject

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -119,6 +119,12 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
 
                 assert_no_enqueued_jobs
               end
+
+              it "creates a sync log" do
+                expect { subject }.to change { order.taxjar_transaction_sync_logs.count }.from(0).to(1)
+                expect(order.taxjar_transaction_sync_logs.last.status).to eq "error"
+                expect(order.taxjar_transaction_sync_logs.last.error_message).to include "Order cannot be synced because it was completed before TaxJar reporting was enabled"
+              end
             end
           end
 
@@ -152,6 +158,12 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
                 subject
 
                 assert_no_enqueued_jobs
+              end
+
+              it "creates a sync log" do
+                expect { subject }.to change { order.taxjar_transaction_sync_logs.count }.from(0).to(1)
+                expect(order.taxjar_transaction_sync_logs.last.status).to eq "error"
+                expect(order.taxjar_transaction_sync_logs.last.error_message).to include "Order cannot be synced because it was completed before TaxJar reporting was enabled"
               end
             end
           end
@@ -235,6 +247,12 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
         subject
 
         assert_no_enqueued_jobs
+      end
+
+      it "creates a sync log" do
+        expect { subject }.to change { order.taxjar_transaction_sync_logs.count }.from(0).to(1)
+        expect(order.taxjar_transaction_sync_logs.last.status).to eq "error"
+        expect(order.taxjar_transaction_sync_logs.last.error_message).to include "Order cannot be synced because it was completed before TaxJar reporting was enabled"
       end
     end
   end

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
   end
 
   before do
-    create(:taxjar_configuration, preferred_reporting_enabled: reporting_enabled)
+    create(:taxjar_configuration, preferred_reporting_enabled_at_integer: reporting_enabled_at.to_i)
   end
 
   let(:order_factory) { :order_ready_to_ship }
   let(:order) { with_events_disabled { create order_factory } }
 
   let(:reporting) { instance_spy ::SuperGood::SolidusTaxjar::Reporting }
-  let(:reporting_enabled) { true }
+  let(:reporting_enabled_at) { 1.hour.from_now }
 
   describe "order_recalculated is fired" do
     subject do
@@ -111,8 +111,8 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
               assert_no_enqueued_jobs
             end
 
-            context "when reporting is disabled" do
-              let(:reporting_enabled) { false }
+            context "when the order was completed before reporting was enabled" do
+              let(:reporting_enabled_at) { 1.hour.ago }
 
               it "does nothing" do
                 subject
@@ -145,8 +145,8 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
               end
             end
 
-            context "when reporting is disabled" do
-              let(:reporting_enabled) { false }
+            context "when the order was completed before reporting was enabled" do
+              let(:reporting_enabled_at) { 1.hour.ago }
 
               it "does nothing" do
                 subject
@@ -213,7 +213,7 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
 
     let(:shipment) { create(:shipment, state: 'ready', order: order) }
     let(:order) {
-      with_events_disabled { create :order_with_line_items }
+      with_events_disabled { create :completed_order_with_totals }
     }
     let(:reporting) { instance_spy(::SuperGood::SolidusTaxjar::Reporting) }
 
@@ -228,8 +228,8 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
       end
     end
 
-    context "reporting is disabled" do
-      let(:reporting_enabled) { false }
+    context "when the order was completed before reporting was enabled" do
+      let(:reporting_enabled_at) { 1.hour.ago }
 
       it "doesn't queue to report the transaction" do
         subject

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -34,10 +34,9 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
     context "when the order is completed" do
       context "when the order has not been shipped" do
         it "does nothing" do
-          expect(reporting)
-            .not_to receive(:refund_and_create_new_transaction)
-
           subject
+
+          assert_no_enqueued_jobs
         end
       end
 
@@ -49,10 +48,9 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
         }
 
         it "does nothing" do
-          expect(reporting)
-            .not_to receive(:refund_and_create_new_transaction)
-
           subject
+
+          assert_no_enqueued_jobs
         end
       end
 
@@ -108,20 +106,18 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
 
           context "when the TaxJar transaction is up-to-date" do
             it "does nothing" do
-              expect(reporting)
-                .not_to receive(:refund_and_create_new_transaction)
-
               subject
+
+              assert_no_enqueued_jobs
             end
 
             context "when reporting is disabled" do
               let(:reporting_enabled) { false }
 
               it "does nothing" do
-                expect(reporting)
-                  .not_to receive(:refund_and_create_new_transaction)
-
                 subject
+
+                assert_no_enqueued_jobs
               end
             end
           end
@@ -153,10 +149,9 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
               let(:reporting_enabled) { false }
 
               it "does nothing" do
-                expect(reporting)
-                  .not_to receive(:refund_and_create_new_transaction)
-
                 subject
+
+                assert_no_enqueued_jobs
               end
             end
           end
@@ -164,10 +159,9 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
 
         context "when a TaxJar transaction does not exist on the order" do
           it "does nothing" do
-            expect(reporting)
-              .not_to receive(:refund_and_create_new_transaction)
-
             subject
+
+            assert_no_enqueued_jobs
           end
 
           it(
@@ -186,8 +180,9 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
         let(:order_factory) { :completed_order_with_pending_payment }
 
         it "does nothing" do
-          expect(reporting).not_to receive(:show_or_create_transaction)
           subject
+
+          assert_no_enqueued_jobs
         end
       end
     end
@@ -196,8 +191,9 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
       let(:order_factory) { :order_with_totals }
 
       it "does nothing" do
-        expect(reporting).not_to receive(:show_or_create_transaction)
         subject
+
+        assert_no_enqueued_jobs
       end
     end
   end


### PR DESCRIPTION
What is the goal of this PR?
---

To gracefully handle updates to orders that were never reported at time of purchase.


How do you manually test these changes? (if applicable)
---

1. Ensure reporting is disabled
1. Complete an order
1. Enable reporting
1. Issue a refund (or some other change that fires `order_recalculated`)
1. Verify the order is not reported
1. Verify there is a sync log with an error

Merge Checklist
---

- [x] Run the manual tests
- [ ] Update the changelog
