### PR TITLE
[221] Create sync logs for replace transaction jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - [#238](https://github.com/SuperGoodSoft/solidus_taxjar/pull/238) Drop support for loading of reporting subscriber for Solidus < 2.11
 - [#237](https://github.com/SuperGoodSoft/solidus_taxjar/pull/237) Sort order transactions by `created_at`
 - [#236](https://github.com/SuperGoodSoft/solidus_taxjar/pull/236) Don't send cancelled or returned line items
+- [#225](https://github.com/SuperGoodSoft/solidus_taxjar/pull/225) Create sync logs for replace transaction jobs
 
 ## Upgrading Instructions
 

--- a/app/jobs/super_good/solidus_taxjar/replace_transaction_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/replace_transaction_job.rb
@@ -14,6 +14,13 @@ module SuperGood
           order_transaction: order_transaction,
           status: :success
         )
+
+      rescue Taxjar::Error => exception
+        SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
+          order: order,
+          status: :error,
+          error_message: exception.message
+        )
       end
     end
   end

--- a/app/jobs/super_good/solidus_taxjar/replace_transaction_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/replace_transaction_job.rb
@@ -10,7 +10,6 @@ module SuperGood
 
         SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
           order: order,
-          refund_transaction: order_transaction.refund_transaction,
           order_transaction: order_transaction,
           status: :success
         )

--- a/app/jobs/super_good/solidus_taxjar/replace_transaction_job.rb
+++ b/app/jobs/super_good/solidus_taxjar/replace_transaction_job.rb
@@ -6,7 +6,14 @@ module SuperGood
       queue_as { SuperGood::SolidusTaxjar.job_queue }
 
       def perform(order)
-        SuperGood::SolidusTaxjar.reporting.refund_and_create_new_transaction(order)
+        order_transaction = SuperGood::SolidusTaxjar.reporting.refund_and_create_new_transaction(order)
+
+        SuperGood::SolidusTaxjar::TransactionSyncLog.create!(
+          order: order,
+          refund_transaction: order_transaction.refund_transaction,
+          order_transaction: order_transaction,
+          status: :success
+        )
       end
     end
   end

--- a/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
+++ b/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
@@ -2,6 +2,7 @@ class SuperGood::SolidusTaxjar::TransactionSyncLog < ApplicationRecord
   belongs_to :transaction_sync_batch, optional: true
   belongs_to :order, class_name: "Spree::Order"
   belongs_to :order_transaction, optional: true
+  belongs_to :refund_transaction, optional: true
 
   enum status: [:processing, :success, :error]
 end

--- a/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
+++ b/app/models/super_good/solidus_taxjar/transaction_sync_log.rb
@@ -2,7 +2,7 @@ class SuperGood::SolidusTaxjar::TransactionSyncLog < ApplicationRecord
   belongs_to :transaction_sync_batch, optional: true
   belongs_to :order, class_name: "Spree::Order"
   belongs_to :order_transaction, optional: true
-  belongs_to :refund_transaction, optional: true
+  delegate :refund_transaction, to: :order_transaction, :allow_nil => true
 
   enum status: [:processing, :success, :error]
 end

--- a/app/views/spree/admin/shared/_transaction_sync_log_table.html.erb
+++ b/app/views/spree/admin/shared/_transaction_sync_log_table.html.erb
@@ -3,7 +3,8 @@
     <tr>
       <th>Log ID</th>
       <th>Order</th>
-      <th>TaxJar Transaction ID</th>
+      <th>TaxJar Order Transaction ID</th>
+      <th>TaxJar Refund Transaction ID</th>
       <th>Status</th>
       <th>Error Message</th>
       <th>Created at</th>
@@ -16,6 +17,7 @@
         <td><%= log.id %></td>
         <td><%= link_to log.order.number, spree.edit_admin_order_path(log.order) %></td>
         <td><%= log.order_transaction&.transaction_id || "-" %></td>
+        <td><%= log.refund_transaction&.transaction_id || "-" %></td>
         <td><%= log.status.capitalize %></td>
         <td style="white-space: pre-wrap; width: 150px; overflow-wrap: anywhere;"><%= log.error_message %></td>
         <td><%= log.created_at %></td>

--- a/db/migrate/20230320211309_add_refund_transaction_to_sync_logs.rb
+++ b/db/migrate/20230320211309_add_refund_transaction_to_sync_logs.rb
@@ -1,0 +1,5 @@
+class AddRefundTransactionToSyncLogs < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :solidus_taxjar_transaction_sync_logs, :refund_transaction, foreign_key: {to_table: :solidus_taxjar_refund_transactions}, index: {name: "index_transaction_sync_logs_on_refund_transaction_id"}
+  end
+end

--- a/spec/features/spree/admin/backfill_transactions_spec.rb
+++ b/spec/features/spree/admin/backfill_transactions_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
         expect(page).to_not have_content excluded_order.number
         expect(page).to_not have_content excluded_order.number
         expect(page).to have_content order.number
-        within "tbody td:nth-child(4)" do
+        within "tbody td:nth-child(5)" do
           expect(page).to have_content("Success")
         end
       end
@@ -104,7 +104,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
             expect(page).to have_content("-")
           end
 
-          within "td:nth-child(4)" do
+          within "td:nth-child(5)" do
             expect(page).to have_content("Processing")
           end
 
@@ -125,7 +125,7 @@ RSpec.feature 'Admin Transaction Sync Batches', js: true, vcr: true do
             expect(page).to have_content(success_transaction_sync_log.order_transaction.transaction_id)
           end
 
-          within "td:nth-child(4)" do
+          within "td:nth-child(5)" do
             expect(page).to have_content("Success")
           end
 

--- a/spec/jobs/super_good/solidus_taxjar/replace_transaction_job_spec.rb
+++ b/spec/jobs/super_good/solidus_taxjar/replace_transaction_job_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe SuperGood::SolidusTaxjar::ReplaceTransactionJob do
 
     let(:order) { create :order }
     let(:mock_reporting) { instance_double ::SuperGood::SolidusTaxjar::Reporting }
+    let(:fake_order_transaction) { create :taxjar_order_transaction }
+    let!(:fake_refund_transaction) { create :taxjar_refund_transaction, order_transaction: fake_order_transaction }
+
+    before do
+      allow(mock_reporting)
+        .to receive(:refund_and_create_new_transaction)
+        .and_return(fake_order_transaction)
+      allow(SuperGood::SolidusTaxjar)
+        .to receive(:reporting)
+        .and_return(mock_reporting)
+    end
 
     it "enqueues the job" do
       assert_enqueued_with(job: described_class, args: [order]) do
@@ -14,11 +25,49 @@ RSpec.describe SuperGood::SolidusTaxjar::ReplaceTransactionJob do
     end
 
     it "replaces the transaction when it performs the job" do
-      allow(SuperGood::SolidusTaxjar).to receive(:reporting).and_return(mock_reporting)
-      expect(mock_reporting).to receive(:refund_and_create_new_transaction).with(order)
-
       perform_enqueued_jobs do
         subject
+      end
+
+      expect(mock_reporting)
+        .to have_received(:refund_and_create_new_transaction)
+        .with(order)
+    end
+
+    it "creates multiple transaction sync logs with the order transactions and refund transactions" do
+      expect { perform_enqueued_jobs { subject } }
+        .to change { ::SuperGood::SolidusTaxjar::TransactionSyncLog.count }
+        .by(1)
+
+      expect(::SuperGood::SolidusTaxjar::TransactionSyncLog.last)
+        .to have_attributes(
+          status: "success",
+          refund_transaction: fake_refund_transaction,
+          order_transaction: fake_order_transaction
+        )
+    end
+
+    context "when a replacing the transaction has already partially succeeded" do
+      let(:fake_order_transaction) { create :taxjar_order_transaction }
+      let(:fake_refund_transaction) { nil }
+
+      before do
+        allow(mock_reporting)
+          .to receive(:refund_and_create_new_transaction)
+          .and_return(fake_order_transaction)
+      end
+
+      it "creates a transaction sync log with the order transaction" do
+        expect { perform_enqueued_jobs { subject } }
+          .to change { ::SuperGood::SolidusTaxjar::TransactionSyncLog.count }
+          .by(1)
+
+        expect(::SuperGood::SolidusTaxjar::TransactionSyncLog.last)
+          .to have_attributes(
+            status: "success",
+            order_transaction: fake_order_transaction,
+            refund_transaction: nil
+          )
       end
     end
   end

--- a/spec/requests/spree/admin/order_request_spec.rb
+++ b/spec/requests/spree/admin/order_request_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
     subject { get spree.taxjar_transactions_admin_order_path(order) }
 
     let!(:order) { create(:shipped_order) }
-    let(:order_transaction) { create :taxjar_order_transaction, transaction_id: "Test-123"}
+    let(:order_transaction) { create :taxjar_order_transaction, transaction_id: "Test-123", refund_transaction: refund_transaction}
+    let(:refund_transaction) { create :taxjar_refund_transaction, transaction_id: "Test-123-refund"}
 
     before do
       create :transaction_sync_log, order: order, order_transaction: order_transaction, status: :success
@@ -114,7 +115,7 @@ RSpec.describe Spree::Admin::OrdersController, :type => :request do
 
     it "renders the transaction sync logs" do
       subject
-      expect(response.body).to have_text("#{order.number} Test-123 Success", normalize_ws: true)
+      expect(response.body).to have_text("#{order.number} Test-123 Test-123-refund Success", normalize_ws: true)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,8 @@ VCR.configure do |config|
   end
   config.ignore_hosts(
     "chromedriver.storage.googleapis.com",
+    "googlechromelabs.github.io",
+    "edgedl.me.gvt1.com",
     *driver_urls
   )
   config.filter_sensitive_data('<BEARER_TOKEN>') { |interaction|


### PR DESCRIPTION
What is the goal of this PR?
---

We missed the act of creating refund transaction log objects even though the object type exists

This creates sync logs when replacing a transaction on taxjar

How do you manually test these changes? (if applicable)
---

1. Perform a refund
    * [x] Ensure the appropriate logs are created and displayed in the UI
    * [x] Ensure the refund is performed successfully on TaxJar

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog
