### PR TITLE
Fix reporting for orders with refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - [#218](https://github.com/SuperGoodSoft/solidus_taxjar/pull/218) Removed `order_recalculated` event backport
 - [#216](https://github.com/SuperGoodSoft/solidus_taxjar/pull/216) Add `deface` as a dependency.
 - [#217](https://github.com/SuperGoodSoft/solidus_taxjar/pull/217) Handle updates to orders that have not been reported
+- [#227](https://github.com/SuperGoodSoft/solidus_taxjar/pull/227) Fix reporting for orders with refunds
 
 ## Upgrading Instructions
 

--- a/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/app/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -49,8 +49,10 @@ module SuperGood
         private
 
         def amount_changed?(order)
+          # We use `order.payment_total` to ensure we capture any total changes
+          # from refunds.
           SuperGood::SolidusTaxjar.api.show_latest_transaction_for(order).amount !=
-            (order.total - order.additional_tax_total)
+            (order.payment_total - order.additional_tax_total)
         end
 
         def completed_before_reporting_enabled?(order)

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -38,7 +38,9 @@ module SuperGood
             .merge(
               transaction_id: transaction_id,
               transaction_date: order.completed_at.to_formatted_s(:iso8601),
-              amount: [order.total - order.additional_tax_total, 0].max,
+              # We use `payment_total` to reflect the total liablity
+              # transferred.
+              amount: [order.payment_total - order.additional_tax_total, 0].max,
               shipping: shipping(order),
               sales_tax: sales_tax(order)
             )

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -135,15 +135,14 @@ RSpec.describe SuperGood::SolidusTaxjar::Spree::ReportingSubscriber do
             before do
               allow(dummy_client).to receive(:nexus_regions)
               allow(dummy_client).to receive(:tax_for_order)
-
               with_events_disabled {
-                # We want to ensure that the order is completed, paid, and that
-                # the `ReportingSubscriber#amount_changed?` method returns true.
-                order.line_items.first.update!(price: 33)
+                customer_return = create :customer_return_with_accepted_items, shipped_order: order
+                reimbursement = create :reimbursement, customer_return: customer_return, total: 10
+                create :refund, reimbursement: reimbursement, payment: order.payments.first, amount: 10
                 order.recalculate
-                order.payments.first.update!(amount: order.total)
               }
             end
+
 
             it "enqueue a job to refund and create a new transaction" do
               assert_enqueued_with(

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       total: order_total,
       shipments: [shipment],
       user_id: 12345,
-      completed_at: DateTime.new(2018, 3, 6, 12, 10, 33))
+      completed_at: DateTime.new(2018, 3, 6, 12, 10, 33),
+      payment_total: payment_total)
   end
   let(:order_total) { BigDecimal("123.45") }
+  let(:payment_total) { BigDecimal("110.45") }
 
   let(:store) do
     create(
@@ -299,7 +301,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
     it "returns params for creating/updating an order transaction" do
       expect(subject).to eq({
-        amount: BigDecimal("113.58"),
+        amount: BigDecimal("100.58"),
         customer_id: "12345",
         line_items: [{
           discount: 2,
@@ -325,6 +327,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
     context "when the order is adjusted to 0" do
       let(:order_total) { BigDecimal("0") }
+      let(:payment_total) { BigDecimal("0") }
 
       it "sends the order total as zero" do
         expect(subject[:amount]).to be_zero
@@ -362,7 +365,7 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
       it "excludes the line item" do
         expect(subject).to eq({
-          amount: BigDecimal("113.58"),
+          amount: BigDecimal("100.58"),
           customer_id: "12345",
           line_items: [],
           sales_tax: BigDecimal("9.87"),


### PR DESCRIPTION
What is the goal of this PR?
---

Prior to this change, refunds would not trigger the replace transaction job. This is because we compared `order.total` which does not include refunds/reimbursements. We fix this by calling `order.payment_total` instead as it reflects what the customer actually paid. Finally, we have to make the same change in the reporting code.

How do you manually test these changes? (if applicable)
---

1. Ensure reporting is enabled
1. Complete and ship a new order
1. Refund one or more of the line items
1. Verify the order has been re-reported to TaxJar with the new amount.

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog
