### PR TITLE
Bump Ruby version on master build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ jobs:
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/store-test-results
   run-specs-with-master:
-    executor: solidusio_extensions/postgres
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: "3.0"
     steps:
       - browser-tools/install-browser-tools
       - checkout


### PR DESCRIPTION
What is the goal of this PR?
---

This is now failing because `solidus_sample` requires Ruby 3.0.

How do you manually test these changes? (if applicable)
---

1. Do a thing
    * [ ] Assert a result

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog

Screenshots
---
N/A
