### PR TITLE
Load factories in line with new Solidus conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - [#237](https://github.com/SuperGoodSoft/solidus_taxjar/pull/237) Sort order transactions by `created_at`
 - [#236](https://github.com/SuperGoodSoft/solidus_taxjar/pull/236) Don't send cancelled or returned line items
 - [#225](https://github.com/SuperGoodSoft/solidus_taxjar/pull/225) Create sync logs for replace transaction jobs
+- [#231](https://github.com/SuperGoodSoft/solidus_taxjar/pull/231) Load Solidus factories using new conventions
 
 ## Upgrading Instructions
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,15 @@ and `SOLIDUS_BRANCH` environment variables, respectively. See the
 The database vendor can also be changed from the default (`sqlite3`) by setting
 the `DB` environment variable.
 
+### Testing the extension
+
+When testing your application's integration with this extension you may use its factories.
+You can load Solidus core factories along with this extension's factories using this statement:
+
+```ruby
+SolidusDevSupport::TestingSupport::Factories.load_for(SuperGoodSolidusTaxjar::Engine)
+```
+
 ## Releasing a New Version
 
 1. Update the `master` header in changelog to the version that you're releasing.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,17 +24,7 @@ Capybara.register_driver :solidus_chrome_headless do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options_key => chrome_options)
 end
 
-# This was pulled from `solidus_dev_support` and the glob was updated to allow
-# for a deeper namespacing of our factories folder
-# `lib/solidus_dev_support/testing_support/factories.rb`.
-paths = ::SuperGoodSolidusTaxjar::Engine.root.glob('lib/**/testing_support/factories')
-
-FactoryBot.definition_file_paths = [
-  Spree::TestingSupport::FactoryBot.definition_file_paths,
-  paths,
-].flatten
-
-FactoryBot.reload
+SolidusDevSupport::TestingSupport::Factories.load_for(SuperGoodSolidusTaxjar::Engine)
 
 require "support/solidus_events_helper"
 


### PR DESCRIPTION
This change updates our extension to use the new method provided by `solidus_dev_support` instead of manually requiring the files. This is in line with how `FactoryBot` recommends factories are registered and resolves an issue with our custom override for the `Spree::Address` factory.

Currently the upstream version of `solidus_dev_support` does not handle our use case of having a two folder deep namespace, so this change needs to wait for that to be fixed. We have opened a [PR](https://github.com/solidusio/solidus_dev_support/pull/207) upstream for that to be changed.

**UPDATE:** The PR above has been merged, but we have to wait for an official release for `solidus_dev_support` and upgrade to that before we can merge this.

**UPDATE 2:** `solidus_dev_support` 2.7.0 was released with our fix for namespaced extensions https://github.com/solidusio/solidus_dev_support/releases/tag/v2.7.0

This removes the workaround we introduced when we initially resolved #230.

What is the goal of this PR?
---
Ensure that our extension loads factories in the recommended way. Also ensure that our factory override works.

We've also added some documentation for how to load the factories from this extension into a host application for testing.

How do you manually test these changes? (if applicable)
---

1. Run the test suite
    * [x] Assert all tests pass against supported Solidus versions

Merge Checklist
---

- [x] Update the changelog

