### PR TITLE
Update how we load factories to be more compatible with Solidus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,30 +8,44 @@ orbs:
   solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
-  run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+  run-specs-solidus-current:
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: "3.0"
     steps:
       - checkout
       - browser-tools/install-browser-tools
       - solidusio_extensions/run-tests-solidus-older
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/store-test-results
-  run-specs-with-main:
-    executor: solidusio_extensions/postgres
+  run-specs-solidus-older:
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: "2.7"
+    steps:
+      - checkout
+      - browser-tools/install-browser-tools
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/store-test-results
+  run-specs-solidus-main:
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: "3.1"
     steps:
       - browser-tools/install-browser-tools
       - checkout
       - solidusio_extensions/run-tests-solidus-main
       - solidusio_extensions/store-test-results
-
-
 workflows:
-  "Run specs on supported Solidus versions":
+  "Run specs on current Solidus versions":
     jobs:
-      - run-specs-with-postgres
+      - run-specs-solidus-current
+  "Run specs on older Solidus versions":
+    jobs:
+      - run-specs-solidus-older
   "Run specs on Solidus main":
     jobs:
-      - run-specs-with-main
+      - run-specs-solidus-main
   "Weekly run specs against master":
     triggers:
       - schedule:
@@ -41,4 +55,4 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-main
+      - run-specs-solidus-main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,12 @@ jobs:
       - solidusio_extensions/run-tests-solidus-older
       - solidusio_extensions/run-tests-solidus-current
       - solidusio_extensions/store-test-results
-  run-specs-with-master:
+  run-specs-with-main:
     executor: solidusio_extensions/postgres
     steps:
       - browser-tools/install-browser-tools
       - checkout
-      - solidusio_extensions/run-tests-solidus-master
+      - solidusio_extensions/run-tests-solidus-main
       - solidusio_extensions/store-test-results
 
 
@@ -29,9 +29,9 @@ workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs-with-postgres
-  "Run specs on Solidus master":
+  "Run specs on Solidus main":
     jobs:
-      - run-specs-with-master
+      - run-specs-with-main
   "Weekly run specs against master":
     triggers:
       - schedule:
@@ -41,4 +41,4 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-master
+      - run-specs-with-main

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ git "https://github.com/solidusio/solidus.git", branch: branch do
   gem "solidus_sample"
 end
 
-if (branch == 'master') || (branch >= 'v3.2')
+if (branch == 'main') || (branch >= 'v3.2')
   gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: branch
 else
   gem "solidus_frontend", github: "solidusio/solidus", branch: branch

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ git "https://github.com/solidusio/solidus.git", branch: branch do
   gem "solidus_sample"
 end
 
-if (branch == 'main') || (branch >= 'v3.2')
+if (branch == 'main') || (branch >= 'v4.0')
+  gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: 'main'
+elsif (branch >= 'v3.2') && (branch < 'v4.0')
   gem "solidus_frontend", github: "solidusio/solidus_frontend", branch: branch
 else
   gem "solidus_frontend", github: "solidusio/solidus", branch: branch

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -22,7 +22,7 @@ if [ ! -z $SOLIDUS_BRANCH ]
 then
   BRANCH=$SOLIDUS_BRANCH
 else
-  BRANCH="master"
+  BRANCH="main"
 fi
 
 extension_name="super_good-solidus_taxjar"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,17 @@ Capybara.register_driver :solidus_chrome_headless do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options_key => chrome_options)
 end
 
-factories = Dir["#{::SuperGoodSolidusTaxjar::Engine.root}/lib/super_good/solidus_taxjar/testing_support/factories/**/*_factory.rb"].sort
-factories.each { |f| require f }
+# This was pulled from `solidus_dev_support` and the glob was updated to allow
+# for a deeper namespacing of our factories folder
+# `lib/solidus_dev_support/testing_support/factories.rb`.
+paths = ::SuperGoodSolidusTaxjar::Engine.root.glob('lib/**/testing_support/factories')
+
+FactoryBot.definition_file_paths = [
+  Spree::TestingSupport::FactoryBot.definition_file_paths,
+  paths,
+].flatten
+
+FactoryBot.reload
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
What is the goal of this PR?
---
This is a temporary fix until our PR to `solidus_dev_support` is merged
that allows us to have deeper namespacing of the extension folder
structure.

https://github.com/solidusio/solidus_dev_support/pull/207

This change also updates how we run the CI jobs to separate the current / older versions into separate jobs. With the new Solidus v4.0 release, we still have some work to get the extension passing agains that version as well as `main`. Splitting the jobs allows us to also run each one with a different version of Ruby, which is now required as the `solidus_sample` repo requires Ruby `>= 3.0` for Solidus v4 and `main`.

**NOTE:** There is some overlap in the test runs as `run-specs-solidus-current` will run tests on `v3.2`, `v3.3`, `v3.4` and `v4.0` (on Ruby 3) and `run-specs-solidus-older` will run specs on `v3.2`, `v3.3` and `v3.4` (on Ruby 2.7). The last one is what I changed the Required check to be on, since we’re not passing on 4.0 yet.

Fixes #230.

How do you manually test these changes? (if applicable)
---
* Make sure specs pass against _older_ Solidus versions ~including `main`~
