### PR TITLE
[221] Don't send cancelled or returned line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - [#226](https://github.com/SuperGoodSoft/solidus_taxjar/pull/226) Refactor reporting subscriber logic
 - [#238](https://github.com/SuperGoodSoft/solidus_taxjar/pull/238) Drop support for loading of reporting subscriber for Solidus < 2.11
 - [#237](https://github.com/SuperGoodSoft/solidus_taxjar/pull/237) Sort order transactions by `created_at`
+- [#236](https://github.com/SuperGoodSoft/solidus_taxjar/pull/236) Don't send cancelled or returned line items
 
 ## Upgrading Instructions
 

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -146,7 +146,8 @@ module SuperGood
           # The API appears to error when sent line items with no quantity...
           # but why would you do that anyway.
           line_items.reject do |line_item|
-            line_item.quantity.zero?
+            line_item.quantity.zero? ||
+              !line_item.inventory_units.where.not(state: ['returned', 'canceled']).exists?
           end
         end
 

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -116,7 +116,7 @@ module SuperGood
             line_items: valid_line_items(line_items).map do |line_item|
               {
                 id: line_item.id,
-                quantity: line_item.quantity,
+                quantity: line_item.inventory_units.where.not(state: ['returned', 'canceled']).count,
                 unit_price: line_item.price,
                 discount: discount(line_item),
                 product_tax_code: line_item.tax_category&.tax_code
@@ -130,7 +130,7 @@ module SuperGood
             line_items: valid_line_items(line_items).map do |line_item|
               {
                 id: line_item.id,
-                quantity: line_item.quantity,
+                quantity: line_item.inventory_units.where.not(state: ['returned', 'canceled']).count,
                 product_identifier: line_item.sku,
                 description: line_item.variant.descriptive_name,
                 product_tax_code: line_item.tax_category&.tax_code,

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -116,7 +116,7 @@ module SuperGood
             line_items: valid_line_items(line_items).map do |line_item|
               {
                 id: line_item.id,
-                quantity: line_item.inventory_units.where.not(state: ['returned', 'canceled']).count,
+                quantity: not_canceled_or_retured_inventory_units(line_item).count,
                 unit_price: line_item.price,
                 discount: discount(line_item),
                 product_tax_code: line_item.tax_category&.tax_code
@@ -130,7 +130,7 @@ module SuperGood
             line_items: valid_line_items(line_items).map do |line_item|
               {
                 id: line_item.id,
-                quantity: line_item.inventory_units.where.not(state: ['returned', 'canceled']).count,
+                quantity: not_canceled_or_retured_inventory_units(line_item).count,
                 product_identifier: line_item.sku,
                 description: line_item.variant.descriptive_name,
                 product_tax_code: line_item.tax_category&.tax_code,
@@ -147,7 +147,7 @@ module SuperGood
           # but why would you do that anyway.
           line_items.reject do |line_item|
             line_item.quantity.zero? ||
-              !line_item.inventory_units.where.not(state: ['returned', 'canceled']).exists?
+              !not_canceled_or_retured_inventory_units(line_item).exists?
           end
         end
 
@@ -169,6 +169,10 @@ module SuperGood
           return 0 if line_item.order.total.zero?
 
           line_item.additional_tax_total
+        end
+
+        def not_canceled_or_retured_inventory_units(line_item)
+          line_item.inventory_units.where.not(state: ['returned', 'canceled'])
         end
       end
     end

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -221,6 +221,16 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       end
     end
 
+    context "when some line items have been returned" do
+      before do
+        order.line_items.first.inventory_units.update_all(state: "returned")
+      end
+
+      it "excludes returned line items" do
+        expect(subject).to match(hash_including({ line_items: [] }))
+      end
+    end
+
     context "when the line item has zero quantity" do
       let(:line_item_attributes) do
         attributes_for(
@@ -390,6 +400,16 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
       it "uses the specified transaction_id" do
         expect(subject).to include(transaction_id: "R0123456789")
+      end
+    end
+
+    context "when some line items have been returned" do
+      before do
+        order.line_items.first.inventory_units.update_all(state: "returned")
+      end
+
+      it "excludes returned line items" do
+        expect(subject).to match(hash_including({ line_items: [] }))
       end
     end
   end

--- a/spec/super_good/solidus_taxjar/api_params_spec.rb
+++ b/spec/super_good/solidus_taxjar/api_params_spec.rb
@@ -231,6 +231,17 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
       end
     end
 
+    context "part of a line item has been returned" do
+      before do
+        order.line_items.first.inventory_units.first.update(state: "returned")
+        order.line_items.first.inventory_units.second.update(state: "canceled")
+      end
+
+      it "adjusts the line item quanity" do
+        expect(subject).to match(hash_including({ line_items: [hash_including({quantity:1})] }))
+      end
+    end
+
     context "when the line item has zero quantity" do
       let(:line_item_attributes) do
         attributes_for(
@@ -410,6 +421,17 @@ RSpec.describe SuperGood::SolidusTaxjar::ApiParams do
 
       it "excludes returned line items" do
         expect(subject).to match(hash_including({ line_items: [] }))
+      end
+    end
+
+    context "part of a line item has been returned" do
+      before do
+        order.line_items.first.inventory_units.first.update(state: "returned")
+        order.line_items.first.inventory_units.second.update(state: "canceled")
+      end
+
+      it "adjusts the line item quanity" do
+        expect(subject).to match(hash_including({ line_items: [hash_including({quantity:1})] }))
       end
     end
   end


### PR DESCRIPTION
Prior to this change, each request to TaxJar sent all line items. We
should exclude line items that have been returned or cancelled so the
total of the line items still adds up to the order's payment total.