### PR TITLE
Sort order transactions by created_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - [#227](https://github.com/SuperGoodSoft/solidus_taxjar/pull/227) Fix reporting for orders with refunds
 - [#226](https://github.com/SuperGoodSoft/solidus_taxjar/pull/226) Refactor reporting subscriber logic
 - [#238](https://github.com/SuperGoodSoft/solidus_taxjar/pull/238) Drop support for loading of reporting subscriber for Solidus < 2.11
+- [#237](https://github.com/SuperGoodSoft/solidus_taxjar/pull/237) Sort order transactions by `created_at`
 
 ## Upgrading Instructions
 

--- a/app/models/super_good/solidus_taxjar/order_transaction.rb
+++ b/app/models/super_good/solidus_taxjar/order_transaction.rb
@@ -9,7 +9,7 @@ module SuperGood
       validates_presence_of :transaction_date
 
       def self.latest_for(order)
-        where(order: order).order(transaction_date: :desc).limit(1).first
+        where(order: order).order(transaction_date: :desc, created_at: :desc).limit(1).first
       end
     end
   end

--- a/spec/models/super_good/solidus_taxjar/order_transaction_spec.rb
+++ b/spec/models/super_good/solidus_taxjar/order_transaction_spec.rb
@@ -11,17 +11,19 @@ RSpec.describe SuperGood::SolidusTaxjar::OrderTransaction do
     end
 
     context "when there are one or more order transactions" do
+      let(:transaction_date) { 1.day.ago }
+
       let!(:first_order_transaction) {
         create(
           :taxjar_order_transaction,
-          transaction_date: 2.days.ago,
+          transaction_date: transaction_date,
           order: order
         )
       }
       let!(:latest_order_transaction) {
         create(
           :taxjar_order_transaction,
-          transaction_date: 1.days.ago,
+          transaction_date: transaction_date,
           order: order
         )
       }


### PR DESCRIPTION
Prior to this commit, we ran into issues retrieving the latest order
transaction as many contained the same transaction date. To fix, we add
secondary sorting ordered by `created_at`.

What is the goal of this PR?
---



How do you manually test these changes? (if applicable)
---

1. Do a thing
    * [ ] Assert a result

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog

Screenshots
---
