### PR TITLE
Bump Ruby to 3.0 on CI for older versions of Solidus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
   run-specs-solidus-older:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     steps:
       - checkout
       - browser-tools/install-browser-tools


### PR DESCRIPTION
What is the goal of this PR?
---

Now that Solidus 4.1 is released and Solidus 4.0 was added to the CI
task [^1] for solidus-older we need to bump the version of Ruby used to
3.0.

I left a comment on the PR where this changed in the Orb to point out that this will prevent extensions to run tests against 2.x versions of Ruby, but since that is deprecated now we should do this anyways.

[^1] https://github.com/solidusio/circleci-orbs-extensions/pull/87

How do you manually test these changes? (if applicable)
---

1. Let CI run on `solidus-older`
    * [ ] Assert that the job passes

Merge Checklist
---

- [x] ~Run the mbnual tests~
- [x] ~Update the changelog~

Screenshots
---
N/A
