### PR TITLE
Hard-code order number in refund feature spec

### DIFF
--- a/spec/features/spree/admin/refund_spec.rb
+++ b/spec/features/spree/admin/refund_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.feature 'Refunding an order', js: true do
   stub_authorization!
 
-  let(:order) { create(:shipped_order, line_items_count: 3) }
+  let(:order) { create(:shipped_order, line_items_count: 3, number: "R525233498") }
 
   before do
     country = create(:country, states_required: true)


### PR DESCRIPTION
Prior to this change, this spec may fail because the order number
differs from the order number in the cassette. To solve this, we
hard-code the value from the cassette into the test.

Note that re-recording this cassette may require incrementing the order
number.

What is the goal of this PR?
---



How do you manually test these changes? (if applicable)
---

1. Do a thing
    * [ ] Assert a result

Merge Checklist
---

- [ ] Run the manual tests
- [ ] Update the changelog

Screenshots
---
