### PR TITLE
Let admins manually retry syncing TaxJar transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#244](https://github.com/SuperGoodSoft/solidus_taxjar/pull/244) Let admins manually retry syncing TaxJar transactions
 - [#193](https://github.com/SuperGoodSoft/solidus_taxjar/pull/193) Bump version requirement for `solidus_support` to ">= 0.9.0", and as a result drop support for Rails 5.2.
 - [#190](https://github.com/SuperGoodSoft/solidus_taxjar/pull/190) Add transaction sync batch show page
 - [#188](https://github.com/SuperGoodSoft/solidus_taxjar/pull/188) Show transaction sync batches in user interface

--- a/app/controllers/spree/admin/taxjar_transactions_controller.rb
+++ b/app/controllers/spree/admin/taxjar_transactions_controller.rb
@@ -1,0 +1,37 @@
+module Spree
+  module Admin
+    class TaxjarTransactionsController < Spree::Admin::BaseController
+      include SuperGood::SolidusTaxjar::Reportable
+
+      def retry
+        order = Spree::Order.find_by number: params[:order_id]
+
+        if transaction_replaceable? order
+          replace_transaction order
+          flash[:notice] = "Queued transaction sync job"
+        elsif order_reportable? order
+          report_transaction order
+          flash[:notice] = "Queued transaction sync job"
+        else
+          flash[:error] = "Could not retry sync successfully"
+        end
+
+        redirect_to taxjar_transactions_admin_order_path(params[:order_id])
+      end
+
+      private
+
+      def report_transaction(order)
+        with_reportable(order) do
+          SuperGood::SolidusTaxjar::ReportTransactionJob.perform_later(order)
+        end
+      end
+
+      def replace_transaction(order)
+        with_replaceable(order) do
+          SuperGood::SolidusTaxjar::ReplaceTransactionJob.perform_later(order)
+        end
+      end
+    end
+  end
+end

--- a/app/overrides/spree/admin/orders_controller_override.rb
+++ b/app/overrides/spree/admin/orders_controller_override.rb
@@ -1,6 +1,7 @@
 module Spree
   module Admin
     module OrdersControllerOverride
+      # FIXME: Move this to TaxJar transactions controller.
       def taxjar_transactions
         load_order
       end

--- a/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_order_summary/add_taxjar_reported_at.html.erb.deface
@@ -9,9 +9,10 @@
   </style>
 <% end %>
 
+<% last_success_sync_log = @order.taxjar_transaction_sync_logs.success.order(:created_at).last %>
 <% last_sync_log = @order.taxjar_transaction_sync_logs.order(:created_at).last %>
 <dt>Reported to TaxJar at:</dt>
-<dd> <%= last_sync_log ? pretty_time(last_sync_log.created_at) : "-" %></dd>
+<dd> <%= last_success_sync_log ? pretty_time(last_success_sync_log.created_at) : "-" %></dd>
 <dt>TaxJar Sync: </dt>
 <dd>
   <% last_sync_log_status = if last_sync_log
@@ -26,3 +27,4 @@
     <%= last_sync_log_status.capitalize %>
   </span>
 </dd>
+<dt><%= link_to("TaxJar Sync History", spree.taxjar_transactions_admin_order_path(@order)) %></dt>

--- a/app/overrides/super_good/solidus_taxjar/spree/order_override.rb
+++ b/app/overrides/super_good/solidus_taxjar/spree/order_override.rb
@@ -9,6 +9,7 @@ module SuperGood
             inverse_of: :order
 
           base.has_many :taxjar_transaction_sync_logs,
+            -> { order(:created_at) },
             class_name: "SuperGood::SolidusTaxjar::TransactionSyncLog",
             inverse_of: :order
         end

--- a/app/views/spree/admin/shared/_transaction_sync_log_table.html.erb
+++ b/app/views/spree/admin/shared/_transaction_sync_log_table.html.erb
@@ -1,18 +1,19 @@
-<table>
+<table id="transaction_sync_logs" class="index">
   <thead>
     <tr>
       <th>Log ID</th>
-      <th>Order</th>
-      <th>TaxJar Order Transaction ID</th>
-      <th>TaxJar Refund Transaction ID</th>
-      <th>Status</th>
-      <th>Error Message</th>
-      <th>Created at</th>
-      <th>Updated at</th>
+      <th class="wrap-text">Order</th>
+      <th class="wrap-text">Txn ID</th>
+      <th class="wrap-text">Refund Txn ID</th>
+      <th class="wrap-text">Status</th>
+      <th class="wrap-text">Error</th>
+      <th class="wrap-text">Created at</th>
+      <th class="wrap-text">Updated at</th>
+      <th class="wrap-text"></th>
     </tr>
   </thead>
   <tbody>
-    <% transaction_sync_logs.each do |log| %>
+    <% transaction_sync_logs.each.with_index(1) do |log, index| %>
       <tr>
         <td><%= log.id %></td>
         <td><%= link_to log.order.number, spree.edit_admin_order_path(log.order) %></td>
@@ -22,6 +23,12 @@
         <td style="white-space: pre-wrap; width: 150px; overflow-wrap: anywhere;"><%= log.error_message %></td>
         <td><%= log.created_at %></td>
         <td><%= log.updated_at %></td>
+        <td class="actions">
+          <% # If the latest log is an error show a retry. %>
+          <% if log.error? && transaction_sync_logs.count == index %>
+            <%= link_to_with_icon('repeat', "Retry", admin_order_taxjar_transaction_retry_path(log.order), {method: :post}) %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Spree::Core::Engine.routes.draw do
       member do
         get :taxjar_transactions
       end
+
+      post 'taxjar_transaction/retry', to: "taxjar_transactions#retry"
     end
   end
 end

--- a/lib/super_good/solidus_taxjar/reportable.rb
+++ b/lib/super_good/solidus_taxjar/reportable.rb
@@ -38,7 +38,15 @@ module SuperGood
         end
       end
 
-      # @returns [Boolean] true if the transaction has been previously reported
+      # @return [Boolean] true if the TaxJar reporting is currently enabled
+      #   and the order meets all the other requirements for reporting.
+      def order_reportable?(order)
+        return SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled &&
+          order.completed? &&
+          order.shipped?
+      end
+
+      # @return [Boolean] true if the transaction has been previously reported
       #   to TaxJar, the order is currently in `paid` state and there is a
       #   difference between the total (before tax) on the order in Solidus
       #   and the transaction amount on TaxJar.
@@ -49,12 +57,6 @@ module SuperGood
       end
 
       private
-
-      def order_reportable?(order)
-        return SuperGood::SolidusTaxjar.configuration.preferred_reporting_enabled &&
-          order.completed? &&
-          order.shipped?
-      end
 
       def completed_before_reporting_enabled?(order)
         configuration = SuperGood::SolidusTaxjar.configuration

--- a/spec/features/spree/admin/reporting_to_taxjar_spec.rb
+++ b/spec/features/spree/admin/reporting_to_taxjar_spec.rb
@@ -35,8 +35,6 @@ RSpec.feature 'Reporting orders to TaxJar', js: true, vcr: { allow_unused_http_i
     end
 
     scenario "retry of a previously failed transaction sync" do
-      pending "retry feature is implemented"
-
       visit spree.edit_admin_order_path(order)
 
       perform_enqueued_jobs do
@@ -46,9 +44,22 @@ RSpec.feature 'Reporting orders to TaxJar', js: true, vcr: { allow_unused_http_i
       end
 
       within("#order_tab_summary") do
+        expect(page).to have_text("Reported to TaxJar at: -", normalize_ws: true)
         expect(page).to have_text("TaxJar Sync: Error", normalize_ws: true)
-        expect(page).to have_text("Retry")
+
+        click_on "TaxJar Sync History"
       end
+
+      within("#content-header") do
+        expect(page).to have_content("TaxJar Sync History")
+      end
+
+      within('#transaction_sync_logs') do
+        expect(page).to have_content("Retry")
+        click_on "Retry"
+      end
+
+      expect(page).to have_content("Queued transaction sync job")
     end
   end
 

--- a/spec/requests/spree/admin/taxjar_transactions_request_spec.rb
+++ b/spec/requests/spree/admin/taxjar_transactions_request_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::TaxjarTransactionsController, type: :request do
+  extend Spree::TestingSupport::AuthorizationHelpers::Request
+
+  stub_authorization!
+
+  let(:dummy_taxjar_client) {
+    instance_double Taxjar::Client,
+      nexus_regions: "fake-value"
+  }
+  let(:order) { with_events_disabled { create :shipped_order } }
+
+  before do
+    create :taxjar_configuration,
+      preferred_reporting_enabled_at_integer: 1.hour.ago
+
+    allow(SuperGood::SolidusTaxjar::Api)
+      .to receive(:default_taxjar_client)
+      .and_return(dummy_taxjar_client)
+  end
+
+  describe "POST #retry" do
+    subject { post "/admin/orders/#{order.number}/taxjar_transaction/retry" }
+
+    context "when the order has TaxJar order transactions" do
+      before do
+        order.taxjar_order_transactions << create(
+          :taxjar_order_transaction,
+          order: order,
+          transaction_id: order.number
+        )
+      end
+
+      let(:dummy_taxjar_order) { instance_double ::Taxjar::Order }
+
+      it "replaces the latest order transaction" do
+        allow(::SuperGood::SolidusTaxjar.api)
+          .to receive(:show_latest_transaction_for)
+          .with(order)
+          .once
+
+        allow(dummy_taxjar_client)
+          .to receive(:show_order)
+          .with(order.taxjar_order_transactions.first.transaction_id)
+          .and_return(instance_double ::Taxjar::Order, amount: "fake-amount")
+
+        expect { subject }
+          .to have_enqueued_job(SuperGood::SolidusTaxjar::ReplaceTransactionJob)
+          .once
+      end
+    end
+
+    context "when the order does not have TaxJar order transactions" do
+      it "reports the initial order transaction" do
+        expect { subject }
+          .to have_enqueued_job(SuperGood::SolidusTaxjar::ReportTransactionJob)
+          .once
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,11 +36,10 @@ FactoryBot.definition_file_paths = [
 
 FactoryBot.reload
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
+require "support/solidus_events_helper"
 
 RSpec.configure do |config|
+  config.include SolidusEventsHelper
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
 

--- a/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
+++ b/spec/subscribers/super_good/solidus_taxjar/spree/reporting_subscriber_spec.rb
@@ -1,30 +1,10 @@
 require "spec_helper"
 
-# These tests will excercise either the `ReportinSubscriber` or the
+# These tests will excercise either the `ReportingSubscriber` or the
 # `LegacyReportingSubscriber` depending on the version of Solidus they are
 # run against. The loading of the correct subscriber is handled by the
 # initializer added by this extension's install generator.
 RSpec.describe "ReportingSubscriber" do
-  # We only want to trigger the real event action behaviour as our spec
-  # `subject`s.
-  def with_events_disabled(&block)
-    if SolidusSupport::LegacyEventCompat.using_legacy?
-      allow(Spree::Event).to receive(:fire).and_return(nil)
-    else
-      allow(Spree::Bus).to receive(:publish).and_return(nil)
-    end
-
-    object = yield block
-
-    if SolidusSupport::LegacyEventCompat.using_legacy?
-      allow(Spree::Event).to receive(:fire).and_call_original
-    else
-      allow(Spree::Bus).to receive(:publish).and_call_original
-    end
-
-    object
-  end
-
   before do
     create(:taxjar_configuration, preferred_reporting_enabled_at_integer: reporting_enabled_at.to_i)
   end

--- a/spec/support/solidus_events_helper.rb
+++ b/spec/support/solidus_events_helper.rb
@@ -1,0 +1,26 @@
+module SolidusEventsHelper
+  # We can use this helper method to ensure that events are not run until after
+  # the test setup has been completed. This helps us more easily test side
+  # effects from events or control unintended side effects when attempting to
+  # test functionality that is not event-driven but would otherwise emit events.
+  #
+  # @yield Any test setup you'd like to run without events being emitted.
+  # @return The return value of the test setup in your block.
+  def with_events_disabled(&block)
+    if SolidusSupport::LegacyEventCompat.using_legacy?
+      allow(Spree::Event).to receive(:fire).and_return(nil)
+    else
+      allow(Spree::Bus).to receive(:publish).and_return(nil)
+    end
+
+    object = yield block
+
+    if SolidusSupport::LegacyEventCompat.using_legacy?
+      allow(Spree::Event).to receive(:fire).and_call_original
+    else
+      allow(Spree::Bus).to receive(:publish).and_call_original
+    end
+
+    object
+  end
+end


### PR DESCRIPTION
What is the goal of this PR?
---

Solidus admin users may need to re-sync an order that failed to sync with TaxJar when it was shipped or recalculated last. This pull request exposes a "Retry" button in the list of transaction sync logs if the latest sync log has an error asociated with it.


How do you manually test these changes? (if applicable)
---

1. Create and ship an order with two or more line items.
   * [x] See it sync to the TaxJar reporting dashboard.
   * [x] See the successful sync log in the Solidus admin (**Orders -> My Order -> TaxJar Sync History**).
2. Make changes to the order to make it invalid to TaxJar. (For example, make the tax address zipcode totally invalid.)
3. Return one of the line items to force a new order transaction sync with TaxJar.
   * [x] See the unsuccessful syng log in the Solidus admin.
   * [x] See the "Retry" button.
4. Resolve the issue with the order (i.e. the zipcode).
5. Press the "Retry" button.
   * [x] See it sync to the TaxJar reporting dashboard.
   * [x] See the successful or unsuccessful sync log in the Solidus admin (**Orders -> My Order -> TaxJar Sync History**).

Merge Checklist
---

- [x] Run the manual tests
- [x] Update the changelog

Screenshots
---

<img width="1410" alt="Screenshot 2023-08-28 at 2 53 14 PM" src="https://github.com/SuperGoodSoft/solidus_taxjar/assets/883581/93c596c1-e6e3-4e49-a086-b8ff44772c9f">

