### PR TITLE
Don't depend on the `webdrivers` gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- [#249](https://github.com/SuperGoodSoft/solidus_taxjar/pull/249) Don't depend on `webdrivers` gem
 - [#244](https://github.com/SuperGoodSoft/solidus_taxjar/pull/244) Let admins manually retry syncing TaxJar transactions
 - [#193](https://github.com/SuperGoodSoft/solidus_taxjar/pull/193) Bump version requirement for `solidus_support` to ">= 0.9.0", and as a result drop support for Rails 5.2.
 - [#190](https://github.com/SuperGoodSoft/solidus_taxjar/pull/190) Add transaction sync batch show page

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,13 @@ group :development, :test do
   gem "pry"
   gem "pry-stack_explorer"
   gem "pry-byebug"
+
+  # FIXME:
+  # Once a new version of `solidus_dev_support` is released to RubyGems, we can
+  # use that.
+  gem "solidus_dev_support",
+    github: "solidusio/solidus_dev_support",
+    branch: "main"
 end
 
 gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require File.expand_path("dummy/config/environment.rb", __dir__).tap { |file|
 require "solidus_dev_support/rspec/feature_helper"
 require 'vcr'
 
+require "selenium-webdriver"
+
 chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |options|
   options.add_argument("--window-size=#{CAPYBARA_WINDOW_SIZE.join(',')}")
   options.add_argument("--headless") unless ENV["HEADED"]
@@ -46,14 +48,10 @@ VCR.configure do |config|
   config.ignore_localhost = true
   config.configure_rspec_metadata!
   config.hook_into :webmock
-  driver_urls = Webdrivers::Common.subclasses.map do |driver|
-    Addressable::URI.parse(driver.base_url).host
-  end
   config.ignore_hosts(
     "chromedriver.storage.googleapis.com",
     "googlechromelabs.github.io",
-    "edgedl.me.gvt1.com",
-    *driver_urls
+    "edgedl.me.gvt1.com"
   )
   config.filter_sensitive_data('<BEARER_TOKEN>') { |interaction|
     auths = interaction.request.headers['Authorization'].first


### PR DESCRIPTION
What is the goal of this PR?
---

With the latest releases of Selenium, the `webdrivers` gem is no longer compatible. Upstream, `solidus_dev_support` requires `selenium-webdrivers` explicitly, meaning our Webdrivers-specific configuration will cease to work.

This commit prepares us for the future.

Merge Checklist
---

- [x] Update the changelog

