### PR TITLE
Add a delay before reporting transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#204](https://github.com/SuperGoodSoft/solidus_taxjar/pull/204) Add page to render an orders TaxJar transactions
 - [#201](https://github.com/SuperGoodSoft/solidus_taxjar/pull/201) Allow transaction backfills to be filtered by date range
 - [#244](https://github.com/SuperGoodSoft/solidus_taxjar/pull/244) Let admins manually retry syncing failed TaxJar transactions
+- [#255](https://github.com/SuperGoodSoft/solidus_taxjar/pull/255) Add a delay before reporting transactions
 
 ### Changed
 

--- a/lib/super_good/solidus_taxjar/spree/legacy_reporting_subscriber.rb
+++ b/lib/super_good/solidus_taxjar/spree/legacy_reporting_subscriber.rb
@@ -6,18 +6,33 @@ module SuperGood
         include SolidusSupport::LegacyEventCompat::Subscriber
         include SuperGood::SolidusTaxjar::Reportable
 
+        # FIXME:
+        # This is a workaround until we add a new Solidus event we can subscribe
+        # to. "order_recalculated" occurs too early.
+        #
+        # This delay helps us be sure that `Spree::OrderUpdater#persist_totals`
+        #  has been called, and the `order` transaction has been completed,
+        #  before we report this transaction to TaxJar.
+        #
+        DELAY = 2
+
         event_action :report_or_replace_transaction, event_name: :order_recalculated
 
         def report_or_replace_transaction(event)
           order = event.payload[:order]
 
           with_reportable(order) do
-            SuperGood::SolidusTaxjar::ReportTransactionJob.perform_later(order)
+            SuperGood::SolidusTaxjar::ReportTransactionJob
+              .set(wait: DELAY.seconds)
+              .perform_later(order)
+
             return
           end
 
           with_replaceable(order) do
-            SuperGood::SolidusTaxjar::ReplaceTransactionJob.perform_later(order)
+            SuperGood::SolidusTaxjar::ReplaceTransactionJob
+              .set(wait: DELAY.seconds)
+              .perform_later(order)
           end
         end
       end

--- a/lib/super_good/solidus_taxjar/spree/reporting_subscriber.rb
+++ b/lib/super_good/solidus_taxjar/spree/reporting_subscriber.rb
@@ -5,18 +5,33 @@ module SuperGood
         include Omnes::Subscriber
         include SuperGood::SolidusTaxjar::Reportable
 
+        # FIXME:
+        # This is a workaround until we add a new Solidus event we can subscribe
+        # to. "order_recalculated" occurs too early.
+        #
+        # This delay helps us be sure that `Spree::OrderUpdater#persist_totals`
+        #  has been called, and the `order` transaction has been completed,
+        #  before we report this transaction to TaxJar.
+        #
+        DELAY = 2
+
         handle :order_recalculated, with: :report_or_replace_transaction
 
         def report_or_replace_transaction(event)
           order = event.payload[:order]
 
           with_reportable(order) do
-            SuperGood::SolidusTaxjar::ReportTransactionJob.perform_later(order)
+            SuperGood::SolidusTaxjar::ReportTransactionJob
+              .set(wait: DELAY.seconds)
+              .perform_later(order)
+
             return
           end
 
           with_replaceable(order) do
-            SuperGood::SolidusTaxjar::ReplaceTransactionJob.perform_later(order)
+            SuperGood::SolidusTaxjar::ReplaceTransactionJob
+              .set(wait: DELAY.seconds)
+              .perform_later(order)
           end
         end
       end


### PR DESCRIPTION
What is the goal of this PR?
---

In a test environment, we discovered that sometimes these jobs would be run before an order's new totals had been persisted by the `Spree::OrderUpdater`. This is an effective workaround, but it is just a workaround.

Merge Checklist
---

- [x] Update the changelog

