### PR TITLE
Add Gem version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `SuperGood::SolidusTaxjar`
-
+[![Gem Version](https://badge.fury.io/rb/super_good-solidus_taxjar.svg)](https://badge.fury.io/rb/super_good-solidus_taxjar)
 [![CircleCI build status](https://circleci.com/gh/SuperGoodSoft/solidus_taxjar/tree/master.svg?style=shield)](https://circleci.com/gh/SuperGoodSoft/solidus_taxjar/tree/master)
 
 `SuperGood::SolidusTaxjar` is a [Solidus](https://github.com/solidusio/solidus)


### PR DESCRIPTION
What is the goal of this PR?
---
Now that we're officially in a stable release, let's show it off. It's
also helpful for users of the extension to see the latest published
version.

How do you manually test these changes? (if applicable)
---

1. Look at the README
    * [x] Confirm the gem version is shown as what is released on RubyGems

Merge Checklist
---

- [x] Run the manual tests
- [x] ~Update the changelog~

Screenshots
---
<img width="1123" alt="Screenshot 2024-02-02 at 3 46 02 PM" src="https://github.com/SuperGoodSoft/solidus_taxjar/assets/3153035/831f3534-2921-4c78-ae08-ad84a172c3ce">
